### PR TITLE
Fix missing section dot in bag menu

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -783,6 +783,7 @@ static bool8 SetupBagMenu(void)
     case 13:
         PrintPocketNames(gPocketNamesStringsTable[gBagPosition.pocket], 0);
         CopyPocketNameToWindow(0);
+        DrawPocketIndicatorSquare(5, FALSE);
         DrawPocketIndicatorSquare(gBagPosition.pocket, TRUE);
         gMain.state++;
         break;


### PR DESCRIPTION
Fixes the bug where the dot for "Key Items" section doesn't show up until scrolling to that section.