### PR TITLE
Fix typo in move description for Nuzzle

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -15161,7 +15161,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Nuzzle"),
         .description = COMPOUND_STRING(
-            "Rubs its cheecks against\n"
+            "Rubs its cheeks against\n"
             "the foe, paralyzing it."),
         .effect = EFFECT_HIT,
         .power = 20,


### PR DESCRIPTION
Fixes a minor typo in the move description for Nuzzle: "cheecks" => "cheeks".
