### PR TITLE
Removed Drake from pokenav

### DIFF
--- a/data/text/match_call.inc
+++ b/data/text/match_call.inc
@@ -2273,7 +2273,7 @@ MatchCall_Text_Phoebe::
 	.string "Pokémon.$"
 
 MatchCall_Text_Glacia::
-	.string "Glacia Hello, {PLAYER}.\p"
+	.string "Glacia: Hello, {PLAYER}.\p"
 	.string "I trust you haven't become\n"
 	.string "complacent with your power?\p"
 	.string "If you feel the need to cool your\n"
@@ -2281,7 +2281,7 @@ MatchCall_Text_Glacia::
 	.string "to the Pokémon League…$"
 
 MatchCall_Text_Drake::
-	.string "DRAKE: That voice… {PLAYER}, is it?\n"
+	.string "Cynthia: That voice… {PLAYER}, is it?\n"
 	.string "You sound well…\p"
 	.string "I understand that there is now\n"
 	.string "a facility called the BATTLE\l"

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -478,7 +478,7 @@ static const struct MenuAction sMenuActions_Gender[] = {
 };
 
 static const u8 *const sMalePresetNames[] = {
-    COMPOUND_STRING("Stu"),
+    COMPOUND_STRING("Zal"),
     COMPOUND_STRING("Milton"),
     COMPOUND_STRING("Tom"),
     COMPOUND_STRING("Kenny"),


### PR DESCRIPTION
## Description
Replaced Drake's name with Cynthia's when calling Cynthia in the pokenav after beating E4. Also added a missing colon to Glacia's pokenav dialogue.

## Feature(s) this PR does NOT handle:
Did not change any dialogue for "Cynthia," so Drake's old line still remains. Also left her pokenav profile untouched

## Things to note in the release changelog:
Drake's name removed from Cynthia pokenav call

## **Discord contact info**
kingzal (rhymes with mall)
