### PR TITLE
Added cheatcode aliases/shortcuts

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -4439,17 +4439,29 @@ void EnterCheatCode(void)
 
 void GetCheatCodeFeedback(void)
 {
-    static const u8 sText_CheatCodeDexAll[] = _("DexAll"); // Mark entire Pokedex as seen
-    static const u8 sText_CheatCodeCaughtEmAll[] = _("CaughtAll"); // Mark entire Pokedex as caught
-    static const u8 sText_CheatCodeBestBall[] = _("EZCatch"); // 100% catch rate with all balls
-    static const u8 sText_CheatCodeMega[] = _("Mega"); // give all mega stones
-    static const u8 sText_CheatCodeShinyStarters[] = _("ShinyS"); // guarantee shiny starters
-    static const u8 sText_CheatCodeMaxMoney[] = _("MaxMoney"); // give max money
-    static const u8 sText_CheatCodeShinyRoamers[] = _("ShinyR"); // guarantee shiny roamers
-    // static const u8 sText_CheatCodeGiveMenu[] = _("GiveMenu"); // give max money
+    static const u8 sText_CheatCodeDexAll[]           = _("DexAll");
+    static const u8 sText_CheatCodeDexAllShort[]      = _("DXA");
 
-    // Mark entire Pokedex as seen
-    if (!StringCompare(gStringVar2, sText_CheatCodeDexAll))
+    static const u8 sText_CheatCodeCaughtEmAll[]      = _("CaughtAll");
+    static const u8 sText_CheatCodeCaughtEmAllShort[] = _("CAL");
+
+    static const u8 sText_CheatCodeBestBall[]         = _("EZCatch");
+    static const u8 sText_CheatCodeBestBallShort[]    = _("EZC");
+
+    static const u8 sText_CheatCodeMega[]             = _("Mega");
+
+    static const u8 sText_CheatCodeShinyStarters[]        = _("ShinyS");
+    static const u8 sText_CheatCodeShinyStartersShort[]   = _("SHS");
+
+    static const u8 sText_CheatCodeMaxMoney[]         = _("MaxMoney");
+    static const u8 sText_CheatCodeMaxMoneyShort[]    = _("MMY");
+
+    static const u8 sText_CheatCodeShinyRoamers[]         = _("ShinyR");
+    static const u8 sText_CheatCodeShinyRoamersShort[]    = _("SHR");
+
+    /* 1: DexAll / DXA – toggle full Pokédex seen */
+    if (!StringCompare(gStringVar2, sText_CheatCodeDexAll) ||
+        !StringCompare(gStringVar2, sText_CheatCodeDexAllShort))
     {
         if (FlagGet(FLAG_DEXALL))
             FlagClear(FLAG_DEXALL);
@@ -4458,11 +4470,11 @@ void GetCheatCodeFeedback(void)
         gSpecialVar_Result = 1;
     }
 
-    // Mark entire Pokedex as caught
-    else if (!StringCompare(gStringVar2, sText_CheatCodeCaughtEmAll))
+    /* 2: CaughtAll / CAL – mark all species seen & caught */
+    else if (!StringCompare(gStringVar2, sText_CheatCodeCaughtEmAll) ||
+             !StringCompare(gStringVar2, sText_CheatCodeCaughtEmAllShort))
     {
-        u32 i;
-        for (i = 0; i < NATIONAL_DEX_COUNT; i++)
+        for (u32 i = 0; i < NATIONAL_DEX_COUNT; i++)
         {
             GetSetPokedexFlag(i + 1, FLAG_SET_SEEN);
             GetSetPokedexFlag(i + 1, FLAG_SET_CAUGHT);
@@ -4470,8 +4482,9 @@ void GetCheatCodeFeedback(void)
         gSpecialVar_Result = 2;
     }
 
-    // 100% catch rate with all balls
-    else if (!StringCompare(gStringVar2, sText_CheatCodeBestBall))
+    /* 3: EZCatch / EZC – toggle 100 % catch rate */
+    else if (!StringCompare(gStringVar2, sText_CheatCodeBestBall) ||
+             !StringCompare(gStringVar2, sText_CheatCodeBestBallShort))
     {
         if (FlagGet(FLAG_EZ_CATCH))
             FlagClear(FLAG_EZ_CATCH);
@@ -4480,12 +4493,15 @@ void GetCheatCodeFeedback(void)
         gSpecialVar_Result = 3;
     }
 
-    // give all mega stones
+    /* 4: Mega – handled in script */
     else if (!StringCompare(gStringVar2, sText_CheatCodeMega))
+    {
         gSpecialVar_Result = 4;
+    }
 
-    // guarantee shiny starters
-    else if (!StringCompare(gStringVar2, sText_CheatCodeShinyStarters))
+    /* 5: ShinyS / SHS – toggle shiny starters */
+    else if (!StringCompare(gStringVar2, sText_CheatCodeShinyStarters) ||
+             !StringCompare(gStringVar2, sText_CheatCodeShinyStartersShort))
     {
         if (FlagGet(FLAG_SHINY_STARTERS))
             FlagClear(FLAG_SHINY_STARTERS);
@@ -4494,15 +4510,17 @@ void GetCheatCodeFeedback(void)
         gSpecialVar_Result = 5;
     }
 
-    // sets money to max value
-    else if(!StringCompare(gStringVar2, sText_CheatCodeMaxMoney))
+    /* 6: MaxMoney / MMY – set money to max */
+    else if (!StringCompare(gStringVar2, sText_CheatCodeMaxMoney) ||
+             !StringCompare(gStringVar2, sText_CheatCodeMaxMoneyShort))
     {
         SetMoney(&gSaveBlock1Ptr->money, MAX_MONEY);
         gSpecialVar_Result = 6;
     }
 
-    // guarantee shiny roamers
-    else if (!StringCompare(gStringVar2, sText_CheatCodeShinyRoamers))
+    /* 7: ShinyR / SHR – toggle shiny roamers */
+    else if (!StringCompare(gStringVar2, sText_CheatCodeShinyRoamers) ||
+             !StringCompare(gStringVar2, sText_CheatCodeShinyRoamersShort))
     {
         if (FlagGet(FLAG_SHINY_ROAMERS))
             FlagClear(FLAG_SHINY_ROAMERS);
@@ -4511,17 +4529,10 @@ void GetCheatCodeFeedback(void)
         gSpecialVar_Result = 7;
     }
 
-    // enables "give menu", which is just the give item and give mon features of the debug menu
-    // else if (!StringCompare(gStringVar2, sText_CheatCodeGiveMenu))
-    // {
-    //     if (FlagGet(FLAG_GIVE_MENU))
-    //         FlagClear(FLAG_GIVE_MENU);
-    //     else
-    //         FlagSet(FLAG_GIVE_MENU);
-    //     gSpecialVar_Result = 7;
-    // }
-
-    // Illegal cheat code
+    /* 0: invalid code */
     else
+    {
         gSpecialVar_Result = 0;
+    }
 }
+

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -4440,24 +4440,24 @@ void EnterCheatCode(void)
 void GetCheatCodeFeedback(void)
 {
     static const u8 sText_CheatCodeDexAll[]           = _("DexAll");
-    static const u8 sText_CheatCodeDexAllShort[]      = _("DXA");
+    static const u8 sText_CheatCodeDexAllShort[]      = _("Dxa");
 
     static const u8 sText_CheatCodeCaughtEmAll[]      = _("CaughtAll");
-    static const u8 sText_CheatCodeCaughtEmAllShort[] = _("CAL");
+    static const u8 sText_CheatCodeCaughtEmAllShort[] = _("Cal");
 
     static const u8 sText_CheatCodeBestBall[]         = _("EZCatch");
-    static const u8 sText_CheatCodeBestBallShort[]    = _("EZC");
+    static const u8 sText_CheatCodeBestBallShort[]    = _("Ezc");
 
     static const u8 sText_CheatCodeMega[]             = _("Mega");
 
     static const u8 sText_CheatCodeShinyStarters[]        = _("ShinyS");
-    static const u8 sText_CheatCodeShinyStartersShort[]   = _("SHS");
+    static const u8 sText_CheatCodeShinyStartersShort[]   = _("Shs");
 
     static const u8 sText_CheatCodeMaxMoney[]         = _("MaxMoney");
-    static const u8 sText_CheatCodeMaxMoneyShort[]    = _("MMY");
+    static const u8 sText_CheatCodeMaxMoneyShort[]    = _("Mmy");
 
     static const u8 sText_CheatCodeShinyRoamers[]         = _("ShinyR");
-    static const u8 sText_CheatCodeShinyRoamersShort[]    = _("SHR");
+    static const u8 sText_CheatCodeShinyRoamersShort[]    = _("Shr");
 
     /* 1: DexAll / DXA – toggle full Pokédex seen */
     if (!StringCompare(gStringVar2, sText_CheatCodeDexAll) ||


### PR DESCRIPTION
After ~16 playthroughs, one of the more frustrating things has become entering cheats at the beginning because of the gen 3 keyboard. This could just be a me issue.

(Sorry for the slow typing, not used to emulating on my PC, usually on a handheld)

DexAll + DXA:
https://github.com/user-attachments/assets/97f495bb-416f-4bb1-a81e-20a8efa1748b

CaughtAll + CAL:
https://github.com/user-attachments/assets/a78e95d0-825e-473a-8c78-c05a75593313

EZCatch + EZC:
https://github.com/user-attachments/assets/a5430650-2f36-4777-bd28-886b3c1c85b0

Mega left as is.

ShinyS + SHS:
https://github.com/user-attachments/assets/d3389536-dfe8-40dd-9d6d-0bd4ac133675

MaxMoney + MMY:
https://github.com/user-attachments/assets/28cc524b-d931-4f25-9e90-38a14eb94c0e

ShinyR + SHR:
https://github.com/user-attachments/assets/a02c641d-809f-40d3-be7b-29353fd651d6

Also, after putting those all in, it's probably better to change the shortcuts to initial caps then all lowercase (i.e., Dxa). Gen 3 keyboard behavior is wild. If this is something you're open to, I'll change that and update the PR.
