### PR TITLE
Potential encounter updates

### DIFF
--- a/src/data/wild_encounters.json
+++ b/src/data/wild_encounters.json
@@ -1588,7 +1588,7 @@
               {
                 "min_level": 25,
                 "max_level": 30,
-                "species": "SPECIES_SENTRET"
+                "species": "SPECIES_SKWOVET"
               },
               {
                 "min_level": 25,
@@ -1926,7 +1926,7 @@
               {
                 "min_level": 6,
                 "max_level": 6,
-                "species": "SPECIES_SKWOVET"
+                "species": "SPECIES_SENTRET"
               },
               {
                 "min_level": 6,

--- a/src/data/wild_encounters.json
+++ b/src/data/wild_encounters.json
@@ -1951,7 +1951,7 @@
               {
                 "min_level": 6,
                 "max_level": 6,
-                "species": "SPECIES_PANSAGE"
+                "species": "SPECIES_APPLIN"
               }
             ]
           }
@@ -1990,7 +1990,7 @@
               {
                 "min_level": 6,
                 "max_level": 8,
-                "species": "SPECIES_EKANS"
+                "species": "SPECIES_NOIBAT"
               },
               {
                 "min_level": 6,
@@ -12111,11 +12111,6 @@
               {
                 "min_level": 5,
                 "max_level": 6,
-                "species": "SPECIES_PIDGEY"
-              },
-              {
-                "min_level": 5,
-                "max_level": 6,
                 "species": "SPECIES_MEOWTH"
               },
               {
@@ -12141,7 +12136,12 @@
               {
                 "min_level": 5,
                 "max_level": 6,
-                "species": "SPECIES_PANSEAR"
+                "species": "SPECIES_EKANS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 6,
+                "species": "SPECIES_AXEW"
               }
             ]
           }


### PR DESCRIPTION
I've seen a few people talking about mono dragon being very, very sparse in the early game, and took a look at Radical Red to see how they handle it. I made/am suggesting these changes to add a few options for early game dragons. These are all tested and working.

These are all **heavily** inspired by Radical Red, and I tried to follow as closely as possible:

1. Moved Ekans from Rusturf Tunnel to Rustboro City
	- Ekans is available in Pewter City, after Viridian Forest.
	- Rustboro City is after Petalburg Woods.
2. Added Axew to Rustboro City
	- Axew is available in Pewter City, after Viridian Forest, and before the first gym.
	- Rustboro City is after Petalburg Woods, and before the first gym.
3. Added Applin to Petalburg Woods
	- Applin is available on Route 22 in Radical Red, well before the first gym.
	- Following more closely would be Route 103, but Petalburg Woods seems more lore-consistent.
4. Added Noibat to Rusturf Tunnel
	- Noibat is available in Diglett Tunnel
	- Rusturf Tunnel seems to be the equivalent for that
	- Noibat hates rocks
	- Dawn has one and we deserve one too 😤
![image](https://github.com/user-attachments/assets/2d0de2bc-0dd0-4f32-b348-2353beb02a12)
![image](https://github.com/user-attachments/assets/970eeb6b-4dc9-4365-b77a-c124a681eaa4)
![image](https://github.com/user-attachments/assets/3e00c3ab-e077-4bed-9001-6e2f2a487579)
