### PR TITLE
Added function  for "Level boxes to cap"

### DIFF
--- a/include/caps.h
+++ b/include/caps.h
@@ -22,4 +22,6 @@ u32 GetCurrentLevelCap(void);
 u32 GetSoftLevelCapExpValue(u32 level, u32 expValue);
 u32 GetCurrentEVCap(void);
 
+void LevelBoxesToCap(void);
+
 #endif /* GUARD_CAPS_H */

--- a/src/caps.c
+++ b/src/caps.c
@@ -127,3 +127,7 @@ u32 GetCurrentEVCap(void)
 
     return MAX_TOTAL_EVS;
 }
+
+void LevelBoxesToCap(void)
+{
+}

--- a/src/caps.c
+++ b/src/caps.c
@@ -140,7 +140,9 @@ void LevelBoxesToCap(void)
             u32 species = GetBoxMonData(boxMon, MON_DATA_SPECIES);
             if (species != SPECIES_NONE && species != SPECIES_EGG)
             {
-                SetBoxMonData(boxMon, MON_DATA_EXP, &gExperienceTables[gSpeciesInfo[species].growthRate][currentCap]);
+                u32 markings = GetBoxMonData(boxMon, MON_DATA_MARKINGS);
+                if (markings == 0)
+                    SetBoxMonData(boxMon, MON_DATA_EXP, &gExperienceTables[gSpeciesInfo[species].growthRate][currentCap]);
             }
         }
     }

--- a/src/caps.c
+++ b/src/caps.c
@@ -3,6 +3,7 @@
 #include "event_data.h"
 #include "caps.h"
 #include "pokemon.h"
+#include "pokemon_storage_system.h"
 
 
 u32 GetCurrentLevelCap(void)
@@ -130,4 +131,17 @@ u32 GetCurrentEVCap(void)
 
 void LevelBoxesToCap(void)
 {
+    u32 currentCap = GetCurrentLevelCap();
+    for (u32 boxId = 0; boxId < TOTAL_BOXES_COUNT; boxId++)
+    {
+        for (u32 boxPosition = 0; boxPosition < IN_BOX_COUNT; boxPosition++)
+        {
+            struct BoxPokemon *boxMon = &gPokemonStoragePtr->boxes[boxId][boxPosition];
+            u32 species = GetBoxMonData(boxMon, MON_DATA_SPECIES);
+            if (species != SPECIES_NONE && species != SPECIES_EGG)
+            {
+                SetBoxMonData(boxMon, MON_DATA_EXP, &gExperienceTables[gSpeciesInfo[species].growthRate][currentCap]);
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
Add the function `LevelBoxesToCap` which will level unmarked mons in the boxes to the level cap.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->

https://github.com/user-attachments/assets/f26eeadb-028b-420d-a59b-247b62d378f3



## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Repetitive stress injuries from leveling up many mons manually.

## Feature(s) this PR does NOT handle:
<!-- If your PR contains any unfinished features that are not considered merge-blocking, please list them here for clarity so no one can forget. -->
<!-- If it doesn't apply, feel free to remove this section. -->
Does not handle script calling for this C function

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara