### PR TITLE
Causes Flare/Toxic Boost to prevent chip damage from poison/toxic/burn

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2366,6 +2366,7 @@ u8 DoBattlerEndTurnEffects(void)
         case ENDTURN_POISON:  // poison
             if ((gBattleMons[battler].status1 & STATUS1_POISON)
              && IsBattlerAlive(battler)
+             && ability != ABILITY_TOXIC_BOOST
              && !IsMagicGuardProtected(battler, ability))
             {
                 if (ability == ABILITY_POISON_HEAL)
@@ -2394,6 +2395,7 @@ u8 DoBattlerEndTurnEffects(void)
         case ENDTURN_BAD_POISON:  // toxic poison
             if ((gBattleMons[battler].status1 & STATUS1_TOXIC_POISON)
               && IsBattlerAlive(battler)
+              && ability != ABILITY_TOXIC_BOOST
               && !IsMagicGuardProtected(battler, ability))
             {
                 if (ability == ABILITY_POISON_HEAL)
@@ -2425,6 +2427,7 @@ u8 DoBattlerEndTurnEffects(void)
         case ENDTURN_BURN:  // burn
             if ((gBattleMons[battler].status1 & STATUS1_BURN)
              && IsBattlerAlive(battler)
+             && ability != ABILITY_FLARE_BOOST
              && !IsMagicGuardProtected(battler, ability))
             {
                 gBattleMoveDamage = GetNonDynamaxMaxHP(battler) / (B_BURN_DAMAGE >= GEN_7 ? 16 : 8);

--- a/test/battle/ability/flare_boost.c
+++ b/test/battle/ability/flare_boost.c
@@ -1,0 +1,61 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Flare Boost causes burn to boost Sp. Attack by 50%", s16 damage)
+{
+    bool8 burned;
+    PARAMETRIZE { burned = FALSE; }
+    PARAMETRIZE { burned = TRUE; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_HYPER_VOICE].category == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_DRIFBLIM)
+        {
+            if (burned == TRUE)
+                Status1(STATUS1_BURN);
+            Ability(ABILITY_FLARE_BOOST);
+        }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_HYPER_VOICE); }
+    } SCENE {
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Flare Boost does not prevent burn from lowering Attack by 50%", s16 damage)
+{
+    bool8 burned;
+    PARAMETRIZE { burned = FALSE; }
+    PARAMETRIZE { burned = TRUE; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_TACKLE].category == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_DRIFBLIM)
+        {
+            if (burned == TRUE)
+                Status1(STATUS1_BURN);
+            Ability(ABILITY_FLARE_BOOST);
+        }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Flare Boost prevents damage from burn")
+{
+    GIVEN {
+        PLAYER(SPECIES_FLAREON) { Ability(ABILITY_FLARE_BOOST); Status1(STATUS1_BURN);}
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SPLASH); }
+    } SCENE {
+        NOT HP_BAR(player);
+
+    }
+}

--- a/test/battle/ability/toxic_boost.c
+++ b/test/battle/ability/toxic_boost.c
@@ -1,0 +1,47 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Toxic Boost causes poison to boost Attack by 50%", s16 damage)
+{
+    u8 poisoned;
+    PARAMETRIZE { poisoned = 0; }
+    PARAMETRIZE { poisoned = 1; }
+    PARAMETRIZE { poisoned = 2; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_TACKLE].category == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_FLAREON)
+        {
+            if (poisoned == 1)
+                Status1(STATUS1_POISON);
+            if (poisoned == 2)
+                Status1(STATUS1_TOXIC_POISON);
+            Ability(ABILITY_TOXIC_BOOST);
+        }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[2].damage);
+        EXPECT_EQ(results[1].damage, results[2].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Toxic Boost prevents damage from (Toxic) Poison")
+{
+    u8 status;
+    PARAMETRIZE { status = STATUS1_POISON; }
+    PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
+
+    GIVEN {
+        PLAYER(SPECIES_FLAREON) { Ability(ABILITY_TOXIC_BOOST); Status1(status);}
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SPLASH); }
+    } SCENE {
+        NOT HP_BAR(player);
+
+    }
+}


### PR DESCRIPTION
Pokemon with Flare Boost or Toxic Boost will not take chip damage from Burn and Poison/Toxic respectively.


## Description
In `battle_util.c` a check was added for the the afforementioned abilities in their respective `ENDTURN` cases. These checks happen before `IsMagicGuardProtected`

A few tests were added to confirm the ability changes function as intended. (`flare_boost.c` `toxic_boost.c`)
Regression tests were done to ensure that poison and burn deal damage normally.

## Images/GIFs
![flare_boost_no_dmg](https://github.com/user-attachments/assets/c8620843-8bbd-4860-aa08-52803745ed38) ![toxic_boost_no_dmg](https://github.com/user-attachments/assets/953d09e1-23b5-422c-8ae9-c451a8913ec7)


## **Discord contact info**
kildemal
