### PR TITLE
Fix R acting as turbo A in places where it's not supposed to

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -54,6 +54,7 @@ void InitStandardTextBoxWindows(void);
 void InitTextBoxGfxAndPrinters(void);
 u16 RunTextPrintersAndIsPrinter0Active(void);
 void LoadMessageBoxAndBorderGfx(void);
+void DrawNonOverworldDialogueFrame(u8 WindowId, bool8 copyToVram);
 void DrawDialogueFrame(u8 windowId, bool8 copyToVram);
 void ClearStdWindowAndFrame(u8 windowId, bool8 copyToVram);
 u16 AddTextPrinterParameterized2(u8 windowId, u8 fontId, const u8 *str, u8 speed, void (*callback)(struct TextPrinterTemplate *, u16), u8 fgColor, u8 bgColor, u8 shadowColor);

--- a/src/menu.c
+++ b/src/menu.c
@@ -335,13 +335,19 @@ static inline void *GetWindowFunc_DialogueFrame(void)
     return (gMsgIsSignPost ? WindowFunc_DrawSignFrame : WindowFunc_DrawDialogueFrame);
 }
 
-void DrawDialogueFrame(u8 windowId, bool8 copyToVram)
+
+void DrawNonOverworldDialogueFrame(u8 windowId, bool8 copyToVram)
 {
     CallWindowFunction(windowId, GetWindowFunc_DialogueFrame());
     FillWindowPixelBuffer(windowId, PIXEL_FILL(1));
     PutWindowTilemap(windowId);
     if (copyToVram == TRUE)
         CopyWindowToVram(windowId, COPYWIN_FULL);
+}
+
+void DrawDialogueFrame(u8 windowId, bool8 copyToVram)
+{
+    DrawNonOverworldDialogueFrame(windowId, copyToVram);
     gMain.activeOverworldDialog = TRUE;
 }
 

--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -524,7 +524,7 @@ static void InitItemStorageMenu(u8 taskId, u8 var)
 
 static void ItemStorageMenuPrint(const u8 *textPtr)
 {
-    DrawDialogueFrame(0, FALSE);
+    DrawNonOverworldDialogueFrame(0, FALSE);
     AddTextPrinterParameterized(0, FONT_NORMAL, textPtr, 0, 1, 0, 0);
 }
 
@@ -578,7 +578,7 @@ void CB2_PlayerPCExitBagMenu(void)
 static void ItemStorage_ReshowAfterBagMenu(void)
 {
     LoadMessageBoxAndBorderGfx();
-    DrawDialogueFrame(0, TRUE);
+    DrawNonOverworldDialogueFrame(0, TRUE);
     InitItemStorageMenu(CreateTask(ItemStorage_HandleReturnToProcessInput, 0), 1);
     FadeInFromBlack();
 }
@@ -1247,7 +1247,7 @@ static void ItemStorage_ReturnToMenuSelect(u8 taskId)
     s16 *data = gTasks[taskId].data;
     if (!IsDma3ManagerBusyWithBgCopy())
     {
-        DrawDialogueFrame(0, FALSE);
+        DrawNonOverworldDialogueFrame(0, FALSE);
 
         // Select Withdraw/Toss by default depending on which was just exited
         if (!tInTossMenu)

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -1567,7 +1567,7 @@ static void Task_PCMainMenu(u8 taskId)
     case STATE_LOAD:
         CreateMainMenu(task->tSelectedOption, &task->tWindowId);
         LoadMessageBoxAndBorderGfx();
-        DrawDialogueFrame(0, FALSE);
+        DrawNonOverworldDialogueFrame(0, FALSE);
         FillWindowPixelBuffer(0, PIXEL_FILL(1));
         AddTextPrinterParameterized2(0, FONT_NORMAL, sMainMenuTexts[task->tSelectedOption].desc, TEXT_SKIP_DRAW, NULL, TEXT_COLOR_DARK_GRAY, TEXT_COLOR_WHITE, TEXT_COLOR_LIGHT_GRAY);
         CopyWindowToVram(0, COPYWIN_FULL);

--- a/src/wallclock.c
+++ b/src/wallclock.c
@@ -691,6 +691,8 @@ void CB2_StartWallClock(void)
     LoadWallClockGraphics();
     LZ77UnCompVram(gWallClockStart_Tilemap, (u16 *)BG_SCREEN_ADDR(7));
 
+
+
     taskId = CreateTask(Task_SetClock_WaitFadeIn, 0);
     gTasks[taskId].tHours = 10;
     gTasks[taskId].tMinutes = 0;
@@ -719,6 +721,7 @@ void CB2_StartWallClock(void)
     gSprites[spriteId].data[1] = 90;
 
     WallClockInit();
+    gMain.activeOverworldDialog = FALSE;
 
     AddTextPrinterParameterized(WIN_BUTTON_LABEL, FONT_NORMAL, gText_Confirm3, 0, 1, 0, NULL);
     PutWindowTilemap(WIN_BUTTON_LABEL);


### PR DESCRIPTION
Fixed R acting as turbo A in places where it's not supposed to. The current implementation of Press R to fast forward causes this behavior whenever the game transitions out of the overworld without closing dialogue frames.

## Description

- Added DrawNonOverworldDialogueFrame and turned DrawDialogueFrame into a wrapper for that.

- Manually set gMain.activeOverworldDialog to FALSE when opening the clock.


## **Discord contact info**
kildemal
