### PR TITLE
Fixes ability randomizer randomizing ABILITY_NONE 

### DIFF
--- a/src/randomizer.c
+++ b/src/randomizer.c
@@ -1128,29 +1128,36 @@ static inline bool32 IsAbilityIllegal(u16 ability)
     return FALSE;
 }
 
+
 // Given a species and an abilityNum, returns a replacement for that ability.
 u16 RandomizeAbility(u16 species, u8 abilityNum, u16 originalAbility)
 {
+
     if (RandomizerFeatureEnabled(RANDOMIZE_ABILITIES))
     {
-        struct Sfc32State state;
-        u16 result;
-        u32 seed;
+        u8 actualAbilityNum = abilityNum;
+        // If the ability slot is ABILITY_NONE, find the last valid ability slot
+        if (gSpeciesInfo[species].abilities[abilityNum] == ABILITY_NONE && abilityNum > 0)
+        {
+            // Search backwards from the current slot to find the last valid ability
+            for (s8 i = abilityNum - 1; i >= 0; i--)
+            {
+                if (gSpeciesInfo[species].abilities[i] != ABILITY_NONE)
+                {
+                    actualAbilityNum = i;
+                    break;
+                }
+            }
+        }
 
-        //if (!ShouldRandomizeItem(itemId))
-        //    return abilityNum;
-
-        // Seed the generator using the species and the original abilityNum 
-        seed = ((u32)species) << 8;
-        seed |= abilityNum;
-
-        state = RandomizerRandSeed(RANDOMIZER_REASON_ABILITIES, seed, species);
+        // Seed the generator using the species and the actual ability slot
+        u32 seed = ((u32)species << 8) | actualAbilityNum;
+        struct Sfc32State state = RandomizerRandSeed(RANDOMIZER_REASON_ABILITIES, seed, species);
 
         // Randomize abilities
-        result = sRandomizerAbilityWhitelist[RandomizerNextRange(&state, ABILITY_WHITELIST_SIZE)];
-
-        return result;
+        return sRandomizerAbilityWhitelist[RandomizerNextRange(&state, ABILITY_WHITELIST_SIZE)];
     }
+
     return originalAbility;
 }
 


### PR DESCRIPTION
Adds a check to prevent adding random abilities in slots that don't have non-randomized abilities. Searches backwards from slot to be randomized to find the last valid ability if the current slot has `ABILITY_NONE`

## Description
If a pokemon had an ability slot with `ABILITY_NONE` it would get randomized previously. This fixes this behavior. `ABILITY_NONE` is replaced with the last valid ability slot for the player and then randomized. Functionally this ensures that pokemon don't get extra randomized abilities in slots they don't have access to normally.

## Images
<img width="240" height="160" alt="pokeemerald-9" src="https://github.com/user-attachments/assets/2ca6e1b0-912b-48ff-a58a-ccbb0dfd08cd" />
<img width="240" height="160" alt="pokeemerald-10" src="https://github.com/user-attachments/assets/c2bf954a-8b35-4ef0-956b-fde90b7f5809" />

## **Discord contact info**
kildemal
