### PR TITLE
Adds back using hex orb from the field via register menu

### DIFF
--- a/include/party_menu.h
+++ b/include/party_menu.h
@@ -112,7 +112,7 @@ void ItemUseCB_PokeBall(u8 taskId, TaskFunc task);
 
 // Start hexorb Branch
 void ItemUseCB_UseHexorb(u8 taskId, TaskFunc task);
-void InitPartyMenuForHexorbFromField(u8 taskId);
+void InitPartyMenuForItemUseFromField(u8 taskId);
 // End hexorb Branch
 
 #endif // GUARD_PARTY_MENU_H

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -81,7 +81,7 @@ static void ItemUseOnFieldCB_Honey(u8 taskId);
 static bool32 IsValidLocationForVsSeeker(void);
 // Start hexorb Branch
 void ItemUseOutOfBattle_Hexorb(u8 taskId);
-//void Task_OpenRegisteredHexorb(u8 taskId);
+void Task_OpenRegisteredHexorb(u8 taskId);
 // End hexorb Branch
 
 // EWRAM variables
@@ -1653,35 +1653,35 @@ void ItemUseOutOfBattle_PokeBall(u8 taskId)
 // Start hexorb Branch
 void ItemUseOutOfBattle_Hexorb(u8 taskId)
 {
-    //gItemUseCB = ItemUseCB_UseHexorb;
+    gItemUseCB = ItemUseCB_UseHexorb;
 
     if (gTasks[taskId].tUsingRegisteredKeyItem != TRUE)
     {
-        gItemUseCB = ItemUseCB_UseHexorb;
+
         SetUpItemUseCallback(taskId);
-    }
-    else
-    {
-        // TODO: handle key items with callbacks to menus allow to be used by registering them.
-        DisplayDadsAdviceCannotUseItemMessage(taskId, gTasks[taskId].tUsingRegisteredKeyItem);
     }
     // else
     // {
-    //     gFieldCallback = FieldCB_ReturnToFieldNoScript;
-    //     FadeScreen(FADE_TO_BLACK, 0);
-    //     gTasks[taskId].func = Task_OpenRegisteredHexorb;
+    //     // TODO: handle key items with callbacks to menus allow to be used by registering them.
+    //     DisplayDadsAdviceCannotUseItemMessage(taskId, gTasks[taskId].tUsingRegisteredKeyItem);
     // }
+    else
+    {
+        gFieldCallback = FieldCB_ReturnToFieldNoScript;
+        FadeScreen(FADE_TO_BLACK, 0);
+        gTasks[taskId].func = Task_OpenRegisteredHexorb;
+    }
 }
 
-// void Task_OpenRegisteredHexorb(u8 taskId)
-// {
-//     if (!gPaletteFade.active)
-//     {
-//         CleanupOverworldWindowsAndTilemaps();
-//         InitPartyMenuForHexorbFromField(taskId);
-//         DestroyTask(taskId);
-//     }
-// }
+void Task_OpenRegisteredHexorb(u8 taskId)
+{
+    if (!gPaletteFade.active)
+    {
+        CleanupOverworldWindowsAndTilemaps();
+        InitPartyMenuForItemUseFromField(taskId);
+        DestroyTask(taskId);
+    }
+}
 // End hexorb Branch
 
 #undef tUsingRegisteredKeyItem

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -8312,7 +8312,7 @@ static void Task_RetryHexorbAfterFailedMon(u8 taskId)
     gTasks[taskId].func = Task_HandleChooseMonInput;
 }
 
-void InitPartyMenuForHexorbFromField(u8 taskId)
+void InitPartyMenuForItemUseFromField(u8 taskId)
 {
     InitPartyMenu(PARTY_MENU_TYPE_FIELD, PARTY_LAYOUT_SINGLE, PARTY_ACTION_USE_ITEM, TRUE, PARTY_MSG_USE_ON_WHICH_MON, Task_HandleChooseMonInput, CB2_ReturnToField);
 }


### PR DESCRIPTION
- Adds back the option to use hex orb from field
- Clears ow tilemaps and windows before opening the party party_menu

## Description
Adds back the ability to use hex orb from the field via the register menu. Overworld windows and palettes are cleared properly before opening the party menu. The party menu is opened with the ReturnToField callback. 

No crashes are observed after testing.

## Images
![hex-orb-test](https://github.com/user-attachments/assets/d4852321-a09d-4e16-b728-806ce823dd2b) ![hex-orb-test-2](https://github.com/user-attachments/assets/850b62c4-dd09-42d4-b312-703424d2c814)


## Feature(s) this PR does NOT handle:
Adding this functionality to other items which currently cannot be used from the field.

## **Discord contact info**
kildemal
