### PR TITLE
Fix/sort tms alpha

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -1168,7 +1168,6 @@ void UpdatePocketItemList(u8 pocketId)
     struct BagPocket *pocket = &gBagPockets[pocketId];
     switch (pocketId)
     {
-    case TMHM_POCKET:
     case BERRIES_POCKET:
         SortBerriesOrTMHMs(pocket);
         break;

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -234,6 +234,7 @@ static void SortItemsInBag(u8 pocket, u8 type);
 static void MergeSort(struct ItemSlot* array, u32 low, u32 high, s8 (*comparator)(struct ItemSlot*, struct ItemSlot*));
 static void Merge(struct ItemSlot* array, u32 low, u32 mid, u32 high, s8 (*comparator)(struct ItemSlot*, struct ItemSlot*));
 static s8 CompareItemsAlphabetically(struct ItemSlot* itemSlot1, struct ItemSlot* itemSlot2);
+static s8 CompareTMsHMsAlphabetically(struct ItemSlot* itemSlot1, struct ItemSlot* itemSlot2);
 static s8 CompareItemsByMost(struct ItemSlot* itemSlot1, struct ItemSlot* itemSlot2);
 
 static const struct BgTemplate sBgTemplates_ItemMenu[] =
@@ -2925,6 +2926,7 @@ static void SortItemsInBag(u8 pocket, u8 type)
 {
     struct ItemSlot* itemMem;
     u16 itemAmount;
+    bool32 isTMsHMsPocket = FALSE;
 
     switch (pocket)
     {
@@ -2947,6 +2949,7 @@ static void SortItemsInBag(u8 pocket, u8 type)
     case TMHM_POCKET:
         itemMem = gSaveBlock1Ptr->bagPocket_TMHM;
         itemAmount = BAG_TMHM_COUNT;
+        isTMsHMsPocket = TRUE;
         break;
     case MEGA_STONES_POCKET:
         itemMem = gSaveBlock1Ptr->bagPocket_MegaStones;
@@ -2962,7 +2965,10 @@ static void SortItemsInBag(u8 pocket, u8 type)
         MergeSort(itemMem, 0, itemAmount - 1, CompareItemsByMost);
         break;
     default:
-        MergeSort(itemMem, 0, itemAmount - 1, CompareItemsAlphabetically);
+        if(isTMsHMsPocket)
+            MergeSort(itemMem, 0, itemAmount - 1, CompareTMsHMsAlphabetically);
+        else
+            MergeSort(itemMem, 0, itemAmount - 1, CompareItemsAlphabetically);
         break;
     }
 }
@@ -3018,6 +3024,59 @@ static s8 CompareItemsAlphabetically(struct ItemSlot* itemSlot1, struct ItemSlot
 
     name1 = ItemId_GetName(item1);
     name2 = ItemId_GetName(item2);
+
+    for (i = 0; ; ++i)
+    {
+        if (name1[i] == EOS && name2[i] != EOS)
+            return -1;
+        else if (name1[i] != EOS && name2[i] == EOS)
+            return 1;
+        else if (name1[i] == EOS && name2[i] == EOS)
+            return 0;
+
+        if (name1[i] < name2[i])
+            return -1;
+        else if (name1[i] > name2[i])
+            return 1;
+    }
+
+    return 0; //Will never be reached
+}
+
+static s8 CompareTMsHMsAlphabetically(struct ItemSlot* itemSlot1, struct ItemSlot* itemSlot2)
+{
+
+    u16 item1 = itemSlot1->itemId;
+    u16 item2 = itemSlot2->itemId;
+
+    bool16 isHM1 = (item1 >= ENUM_HM_START_);
+    bool16 isHM2 = (item2 >= ENUM_HM_START_);
+
+    if (item1 == ITEM_NONE)
+        return 1;
+    else if (item2 == ITEM_NONE)
+        return -1;
+
+    // Place all TMs before all HMs
+    if (!isHM1 && isHM2)
+        return -1;
+    if (isHM1 && !isHM2)
+        return 1;
+
+    u16 move1 = ItemIdToBattleMoveId(item1);
+    u16 move2 = ItemIdToBattleMoveId(item2);
+
+    int i;
+    const u8 *name1;
+    const u8 *name2;
+
+    if (move1 == MOVE_NONE)
+        return 1;
+    else if (move2 == MOVE_NONE)
+        return -1;
+
+    name1 = GetMoveName(move1);
+    name2 = GetMoveName(move2);
 
     for (i = 0; ; ++i)
     {


### PR DESCRIPTION
Adds a new comparator and uses that conditionally in the TMs/HMs pocket to sort alphabetically by move name.

## Description
Sorting TMs alphabetically will now sort by the name of the move rather than the TM name.  Auto sort on open is disabled for the TMs pocket as users may desire to persist alpha sort. #91 addresses the need to go back to the default sort by adding an option for it.

## Images
![tm_sort](https://github.com/user-attachments/assets/444950a0-7285-45df-9b11-cd3dd3c93819)

## **Discord contact info**
kildemal
