### PR TITLE
fix (choice lock): updating handling of trick and thief effects

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2969,7 +2969,7 @@ void StealTargetItem(u8 battlerStealer, u8 battlerItem)
     BtlController_EmitSetMonData(battlerItem, BUFFER_A, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[battlerItem].item);  // remove target item
     MarkBattlerForControllerExec(battlerItem);
 
-    if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS && gBattleMons[gBattlerTarget].ability != ABILITY_SAGE_POWER)
+    if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS && GetBattlerAbility(gBattlerTarget) != ABILITY_SAGE_POWER)
         gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
 
     TrySaveExchangedItem(battlerItem, gLastUsedItem);
@@ -5706,7 +5706,7 @@ static bool32 TryKnockOffBattleScript(u32 battlerDef)
 
             gLastUsedItem = gBattleMons[battlerDef].item;
             gBattleMons[battlerDef].item = 0;
-            if (gBattleMons[battlerDef].ability != ABILITY_GORILLA_TACTICS && gBattleMons[battlerDef].ability != ABILITY_SAGE_POWER)
+            if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS && GetBattlerAbility(gBattlerTarget) != ABILITY_SAGE_POWER)
                 gBattleStruct->choicedMove[battlerDef] = MOVE_NONE;
             CheckSetUnburden(battlerDef);
 
@@ -14499,9 +14499,9 @@ static void Cmd_tryswapitems(void)
             BtlController_EmitSetMonData(gBattlerTarget, BUFFER_A, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[gBattlerTarget].item);
             MarkBattlerForControllerExec(gBattlerTarget);
 
-            if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS && gBattleMons[gBattlerTarget].ability != ABILITY_SAGE_POWER)
+            if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS && GetBattlerAbility(gBattlerTarget) != ABILITY_SAGE_POWER)
                 gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
-            if (gBattleMons[gBattlerAttacker].ability != ABILITY_GORILLA_TACTICS && gBattleMons[gBattlerAttacker].ability != ABILITY_SAGE_POWER)
+            if (GetBattlerAbility(gBattlerAttacker) != ABILITY_GORILLA_TACTICS && GetBattlerAbility(gBattlerAttacker) != ABILITY_SAGE_POWER)
                 gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;
 
             gBattlescriptCurrInstr = cmd->nextInstr;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2969,7 +2969,8 @@ void StealTargetItem(u8 battlerStealer, u8 battlerItem)
     BtlController_EmitSetMonData(battlerItem, BUFFER_A, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[battlerItem].item);  // remove target item
     MarkBattlerForControllerExec(battlerItem);
 
-    gBattleStruct->choicedMove[battlerItem] = 0;
+    if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS && gBattleMons[gBattlerTarget].ability != ABILITY_SAGE_POWER)
+        gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
 
     TrySaveExchangedItem(battlerItem, gLastUsedItem);
 }
@@ -5706,7 +5707,7 @@ static bool32 TryKnockOffBattleScript(u32 battlerDef)
             gLastUsedItem = gBattleMons[battlerDef].item;
             gBattleMons[battlerDef].item = 0;
             if (gBattleMons[battlerDef].ability != ABILITY_GORILLA_TACTICS && gBattleMons[battlerDef].ability != ABILITY_SAGE_POWER)
-                gBattleStruct->choicedMove[battlerDef] = 0;
+                gBattleStruct->choicedMove[battlerDef] = MOVE_NONE;
             CheckSetUnburden(battlerDef);
 
             // In Gen 5+, Knock Off removes the target's item rather than rendering it unusable.
@@ -14498,8 +14499,10 @@ static void Cmd_tryswapitems(void)
             BtlController_EmitSetMonData(gBattlerTarget, BUFFER_A, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[gBattlerTarget].item);
             MarkBattlerForControllerExec(gBattlerTarget);
 
-            gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
-            gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;
+            if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS && gBattleMons[gBattlerTarget].ability != ABILITY_SAGE_POWER)
+                gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
+            if (gBattleMons[gBattlerAttacker].ability != ABILITY_GORILLA_TACTICS && gBattleMons[gBattlerAttacker].ability != ABILITY_SAGE_POWER)
+                gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;
 
             gBattlescriptCurrInstr = cmd->nextInstr;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
Knock Off correctly handled overlapping choice lock with Sage Power/Gorilla Tactics, but this was never applied to the battle scripts for thief or trick effects. I also adjusted all three to reference MOVE_NONE for the choice lock move replacement instead of 0, hopefully improving AI behavior consistency.

## Issue(s) that this PR fixes
Bug report on discord - https://discord.com/channels/1303930187976802374/1422202707552243804 . I uploaded a save file to test with. Testing sequence:
Turn 1 - Abomasnow switch out to Azumarill. Darmanitan-G will choice lock into fire punch.
Turn 2 - Darmantian-G will again use choice locked fire punch. Azumarill uses Covet, stealing Darmanitan-G's Choice Scarf. Before this fix, this removes the choice lock entirely.
Turn 3 - Azumarill switch to Delphox. Before this fix, Darmanitan-G will use Earthquake against Azumarill as its best move selected by the AI with choice lock removed. With this fix, Darmanitan-G will again use Fire Punch, as is expected behavior.
Additionally, if you give Azumarill the move Trick over any move and give it a held item via the debug menu, and use Trick on Turn 2 to swap items, the same behavior can be tested.

## Contributors
@MaximeGr00

## **Discord contact info**
ghostyboyy97
