### PR TITLE
fix (AI switch logic): update AI's stored field state at time of switch to correctly see on-field abilities

### DIFF
--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -678,6 +678,11 @@ static void OpponentHandleChoosePokemon(u32 battler)
         if (IsSwitchOutEffect(gMovesInfo[gCurrentMove].effect) || AI_DATA->ejectButtonSwitch || AI_DATA->ejectPackSwitch)
             switchType = SWITCH_MID_BATTLE;
         
+        // reset the AI data to consider the correct on-field state at time of switch
+        SetBattlerAiData(GetBattlerAtPosition(B_POSITION_PLAYER_LEFT), AI_DATA);
+        if (IsDoubleBattle())
+            SetBattlerAiData(GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT), AI_DATA);
+        
         chosenMonId = GetMostSuitableMonToSwitchInto(battler, switchType);
         if (chosenMonId == PARTY_SIZE)
         {


### PR DESCRIPTION
## Description
This fix updates the AI's knowledge of the player's Pokemon right before deciding a switch-in candidate, so that the AI sees on field abilities correctly for cases like the player using pivot moves and on the turn the player mega evolves.

## **People who collaborated with me in this PR**
@MaximeGr00
@AlexOn1ine

## Things to note in the release changelog:
- Fixed the AI's ability to see the field state correctly when a pivot move was used by the player or when the player mega evolves, and the AI is determining a post-KO switch.

## **Discord contact info**
ghostyboyy97
