### PR TITLE
fix (dynamic move typing): AI able to see dynamic move types correctly at switch-in calc

### DIFF
--- a/include/battle_main.h
+++ b/include/battle_main.h
@@ -80,7 +80,7 @@ s32 GetWhichBattlerFaster(u32 battler1, u32 battler2, bool32 ignoreChosenMoves);
 void RunBattleScriptCommands_PopCallbacksStack(void);
 void RunBattleScriptCommands(void);
 void SpecialStatusesClear(void);
-u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost);
+u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost, bool32 state);
 void SetTypeBeforeUsingMove(u32 move, u32 battlerAtk);
 bool32 IsWildMonSmart(void);
 u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer *trainer, bool32 firstTrainer, u32 battleTypeFlags, u16 seed);

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -936,7 +936,7 @@ const u8 *GetMoveName(u16 moveId);
 const u8 *GetMoveAnimationScript(u16 moveId);
 void UpdateDaysPassedSinceFormChange(u16 days);
 void TrySetDayLimitToFormChange(struct Pokemon *mon);
-u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler);
+u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, bool32 state);
 bool32 IsRegionalForm(u16 speciesId);
 bool32 HasRegionalForm(u16 speciesId);
 

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1786,7 +1786,7 @@ static void MoveSelectionDisplayMoveType(u32 battler)
     else if (P_SHOW_DYNAMIC_TYPES) // Non-vanilla changes to battle UI showing dynamic types
     {
         struct Pokemon *mon = &gPlayerParty[gBattlerPartyIndexes[battler]];
-        type = CheckDynamicMoveType(mon, moveInfo->moves[gMoveSelectionCursor[battler]], battler);
+        type = CheckDynamicMoveType(mon, moveInfo->moves[gMoveSelectionCursor[battler]], battler, gMain.inBattle);
     }
     end = StringCopy(txtPtr, gTypesInfo[type].name);
 
@@ -2467,7 +2467,7 @@ static u32 CheckTypeEffectiveness(u32 targetId, u32 battler)
     struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
     struct Pokemon *mon = &gPlayerParty[gBattlerPartyIndexes[battler]];
     u32 move = moveInfo->moves[gMoveSelectionCursor[battler]];
-    u32 moveType = CheckDynamicMoveType(mon, move, battler);
+    u32 moveType = CheckDynamicMoveType(mon, move, battler, gMain.inBattle);
 
     if (move != MOVE_NONE && move != MOVE_UNAVAILABLE && gMovesInfo[move].power > 0)
     {

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5957,12 +5957,12 @@ bool32 TrySetAteType(u32 move, u32 battlerAtk, u32 attackerAbility)
 
 // Returns TYPE_NONE if type doesn't change.
 // NULL can be passed to ateBoost to avoid applying ate-ability boosts when opening the summary screen in-battle.
-u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost)
+u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost, bool32 state)
 {
     u32 moveType = gMovesInfo[move].type;
     u32 moveEffect = gMovesInfo[move].effect;
     u32 species, heldItem, holdEffect, ability, type1, type2, type3;
-    bool32 monInBattle = gMain.inBattle && gPartyMenu.menuType != PARTY_MENU_TYPE_IN_BATTLE;
+    bool32 monInBattle = state;
 
     if (move == MOVE_STRUGGLE)
         return TYPE_NORMAL;
@@ -6192,7 +6192,8 @@ void SetTypeBeforeUsingMove(u32 move, u32 battler)
     moveType = GetDynamicMoveType(&GetBattlerParty(battler)[gBattlerPartyIndexes[battler]],
                                   move,
                                   battler,
-                                  &gBattleStruct->ateBoost[battler]);
+                                  &gBattleStruct->ateBoost[battler],
+                                  gMain.inBattle);
     if (moveType != TYPE_NONE)
         gBattleStruct->dynamicMoveType = moveType | F_DYNAMIC_TYPE_SET;
 

--- a/src/bw_summary_screen.c
+++ b/src/bw_summary_screen.c
@@ -5062,7 +5062,7 @@ static void SetMoveTypeIcons(void)
         {
             type = gMovesInfo[summary->moves[i]].type;
             if (P_SHOW_DYNAMIC_TYPES)
-                type = CheckDynamicMoveType(mon, summary->moves[i], 0);
+                type = CheckDynamicMoveType(mon, summary->moves[i], 0, gMain.inBattle);
             SetTypeSpritePosAndPal(type, 8, 16 + (i * 28), i + SPRITE_ARR_ID_TYPE);
         }
             
@@ -5090,7 +5090,7 @@ static void SetNewMoveTypeIcon(void)
     struct Pokemon *mon = &sMonSummaryScreen->currentMon;
 
     if (P_SHOW_DYNAMIC_TYPES)
-        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0);
+        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0, gMain.inBattle);
 
     if (sMonSummaryScreen->newMove == MOVE_NONE)
     {

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -7598,9 +7598,9 @@ void UpdateDaysPassedSinceFormChange(u16 days)
     }
 }
 
-u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler)
+u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, bool32 state)
 {
-    u32 moveType = GetDynamicMoveType(mon, move, battler, NULL);
+    u32 moveType = GetDynamicMoveType(mon, move, battler, NULL, state);
     if (moveType != TYPE_NONE)
         return moveType;
     return gMovesInfo[move].type;

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -4073,7 +4073,7 @@ static void SetMoveTypeIcons(void)
         {
             type = gMovesInfo[summary->moves[i]].type;
             if (P_SHOW_DYNAMIC_TYPES)
-                type = CheckDynamicMoveType(mon, summary->moves[i], 0);
+                type = CheckDynamicMoveType(mon, summary->moves[i], 0, gMain.inBattle);
             SetTypeSpritePosAndPal(type, 85, 32 + (i * 16), i + SPRITE_ARR_ID_TYPE);
         }
         else
@@ -4102,7 +4102,7 @@ static void SetNewMoveTypeIcon(void)
     struct Pokemon *mon = &sMonSummaryScreen->currentMon;
 
     if (P_SHOW_DYNAMIC_TYPES)
-        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0);
+        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0, gMain.inBattle);
 
     if (sMonSummaryScreen->newMove == MOVE_NONE)
     {


### PR DESCRIPTION
## Description
Previously, GetDynamicMoveType() would use the mon currently on the field/just KO'd when checking for dynamic move typing due to the inclusion of "&& gPartyMenu.menuType != PARTY_MENU_TYPE_IN_BATTLE" in the monInBattle boolean. removing that second half and instead checking the in-battle state as an argument sent in (emulating upstream behavior) seems to fix dynamic typing at switchin and still displays dynamic typing in party menus correctly.

## **People who collaborated with me in this PR**
@MaximeGr00

## Things to note in the release changelog:
- AI will see Hidden Power type correctly when determining switch-in candidates
- AI will see Ivy Cudgel type correctly when determining switch-in candidates

## **Discord contact info**
ghostyboyy97
