### PR TITLE
fix (scoring): AI skip scoring of explosion effects in CompareDamagingMoves when shouldConsiderExplosion = false

### DIFF
--- a/include/battle_main.h
+++ b/include/battle_main.h
@@ -80,7 +80,7 @@ s32 GetWhichBattlerFaster(u32 battler1, u32 battler2, bool32 ignoreChosenMoves);
 void RunBattleScriptCommands_PopCallbacksStack(void);
 void RunBattleScriptCommands(void);
 void SpecialStatusesClear(void);
-u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost);
+u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost, bool32 state);
 void SetTypeBeforeUsingMove(u32 move, u32 battlerAtk);
 bool32 IsWildMonSmart(void);
 u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer *trainer, bool32 firstTrainer, u32 battleTypeFlags, u16 seed);

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -936,7 +936,7 @@ const u8 *GetMoveName(u16 moveId);
 const u8 *GetMoveAnimationScript(u16 moveId);
 void UpdateDaysPassedSinceFormChange(u16 days);
 void TrySetDayLimitToFormChange(struct Pokemon *mon);
-u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler);
+u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, bool32 state);
 bool32 IsRegionalForm(u16 speciesId);
 bool32 HasRegionalForm(u16 speciesId);
 

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3217,6 +3217,10 @@ static void AI_CompareDamagingMoves(u32 battlerAtk, u32 battlerDef)
                     tempMoveScores[i] = 0;
                     isTwoTurnNotSemiInvulnerableMove[i] = FALSE;
                 }
+                else if (gMovesInfo[moves[i]].effect == EFFECT_EXPLOSION && AI_DATA->shouldConsiderExpolsion == FALSE){
+                    noOfHits[i] = -1;
+                    tempMoveScores[i] = 0;
+                }
                 else if (noOfHits[i] < leastHits && noOfHits[i] != 0)
                 {
                     leastHits = noOfHits[i];

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1786,7 +1786,7 @@ static void MoveSelectionDisplayMoveType(u32 battler)
     else if (P_SHOW_DYNAMIC_TYPES) // Non-vanilla changes to battle UI showing dynamic types
     {
         struct Pokemon *mon = &gPlayerParty[gBattlerPartyIndexes[battler]];
-        type = CheckDynamicMoveType(mon, moveInfo->moves[gMoveSelectionCursor[battler]], battler);
+        type = CheckDynamicMoveType(mon, moveInfo->moves[gMoveSelectionCursor[battler]], battler, gMain.inBattle);
     }
     end = StringCopy(txtPtr, gTypesInfo[type].name);
 
@@ -2467,7 +2467,7 @@ static u32 CheckTypeEffectiveness(u32 targetId, u32 battler)
     struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
     struct Pokemon *mon = &gPlayerParty[gBattlerPartyIndexes[battler]];
     u32 move = moveInfo->moves[gMoveSelectionCursor[battler]];
-    u32 moveType = CheckDynamicMoveType(mon, move, battler);
+    u32 moveType = CheckDynamicMoveType(mon, move, battler, gMain.inBattle);
 
     if (move != MOVE_NONE && move != MOVE_UNAVAILABLE && gMovesInfo[move].power > 0)
     {

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5957,12 +5957,12 @@ bool32 TrySetAteType(u32 move, u32 battlerAtk, u32 attackerAbility)
 
 // Returns TYPE_NONE if type doesn't change.
 // NULL can be passed to ateBoost to avoid applying ate-ability boosts when opening the summary screen in-battle.
-u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost)
+u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost, bool32 state)
 {
     u32 moveType = gMovesInfo[move].type;
     u32 moveEffect = gMovesInfo[move].effect;
     u32 species, heldItem, holdEffect, ability, type1, type2, type3;
-    bool32 monInBattle = gMain.inBattle && gPartyMenu.menuType != PARTY_MENU_TYPE_IN_BATTLE;
+    bool32 monInBattle = state;
 
     if (move == MOVE_STRUGGLE)
         return TYPE_NORMAL;
@@ -6192,7 +6192,8 @@ void SetTypeBeforeUsingMove(u32 move, u32 battler)
     moveType = GetDynamicMoveType(&GetBattlerParty(battler)[gBattlerPartyIndexes[battler]],
                                   move,
                                   battler,
-                                  &gBattleStruct->ateBoost[battler]);
+                                  &gBattleStruct->ateBoost[battler],
+                                  gMain.inBattle);
     if (moveType != TYPE_NONE)
         gBattleStruct->dynamicMoveType = moveType | F_DYNAMIC_TYPE_SET;
 

--- a/src/bw_summary_screen.c
+++ b/src/bw_summary_screen.c
@@ -5062,7 +5062,7 @@ static void SetMoveTypeIcons(void)
         {
             type = gMovesInfo[summary->moves[i]].type;
             if (P_SHOW_DYNAMIC_TYPES)
-                type = CheckDynamicMoveType(mon, summary->moves[i], 0);
+                type = CheckDynamicMoveType(mon, summary->moves[i], 0, gMain.inBattle);
             SetTypeSpritePosAndPal(type, 8, 16 + (i * 28), i + SPRITE_ARR_ID_TYPE);
         }
             
@@ -5090,7 +5090,7 @@ static void SetNewMoveTypeIcon(void)
     struct Pokemon *mon = &sMonSummaryScreen->currentMon;
 
     if (P_SHOW_DYNAMIC_TYPES)
-        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0);
+        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0, gMain.inBattle);
 
     if (sMonSummaryScreen->newMove == MOVE_NONE)
     {

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -7598,9 +7598,9 @@ void UpdateDaysPassedSinceFormChange(u16 days)
     }
 }
 
-u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler)
+u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, bool32 state)
 {
-    u32 moveType = GetDynamicMoveType(mon, move, battler, NULL);
+    u32 moveType = GetDynamicMoveType(mon, move, battler, NULL, state);
     if (moveType != TYPE_NONE)
         return moveType;
     return gMovesInfo[move].type;

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -4073,7 +4073,7 @@ static void SetMoveTypeIcons(void)
         {
             type = gMovesInfo[summary->moves[i]].type;
             if (P_SHOW_DYNAMIC_TYPES)
-                type = CheckDynamicMoveType(mon, summary->moves[i], 0);
+                type = CheckDynamicMoveType(mon, summary->moves[i], 0, gMain.inBattle);
             SetTypeSpritePosAndPal(type, 85, 32 + (i * 16), i + SPRITE_ARR_ID_TYPE);
         }
         else
@@ -4102,7 +4102,7 @@ static void SetNewMoveTypeIcon(void)
     struct Pokemon *mon = &sMonSummaryScreen->currentMon;
 
     if (P_SHOW_DYNAMIC_TYPES)
-        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0);
+        type = CheckDynamicMoveType(mon, sMonSummaryScreen->newMove, 0, gMain.inBattle);
 
     if (sMonSummaryScreen->newMove == MOVE_NONE)
     {

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -109,3 +109,65 @@ AI_SINGLE_BATTLE_TEST("AI will select Throat Chop if the sound move is the best 
         TURN { EXPECT_MOVE(opponent, MOVE_THROAT_CHOP); MOVE(player, MOVE_HYPER_VOICE);}
     }
 }
+
+AI_SINGLE_BATTLE_TEST("Explosion interaction - glalie should correctly score crunch over EQ when high enough HP, or pick explosion when it's viable"){
+
+    u32 hpVal;
+    PARAMETRIZE { hpVal = 1; }
+    PARAMETRIZE { hpVal = 138; }
+
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_CLOYSTER) {
+            Level(44);
+            HP(68); 
+            Item(ITEM_SITRUS_BERRY); 
+            Nature(NATURE_ADAMANT);
+            Ability(ABILITY_SHELL_ARMOR);
+            Moves(MOVE_DETECT, MOVE_RAZOR_SHELL, MOVE_ICICLE_SPEAR, MOVE_ICE_SHARD);
+        }
+        OPPONENT(SPECIES_GLALIE_MEGA) {
+            Level(44);
+            HP(hpVal);
+            Nature(NATURE_JOLLY);
+            Ability(ABILITY_REFRIGERATE);
+            Moves(MOVE_RETURN, MOVE_EARTHQUAKE, MOVE_EXPLOSION, MOVE_CRUNCH);
+        }
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_RAZOR_SHELL);
+            EXPECT_MOVE(opponent, hpVal == 1 ? MOVE_EXPLOSION : MOVE_EARTHQUAKE);
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("Explosion interaction - glalie should correctly score crunch over EQ when high enough HP, or pick low sweep over explosion due to explosion negative effect"){
+
+    u32 hpVal;
+    PARAMETRIZE { hpVal = 1; }
+    PARAMETRIZE { hpVal = 138; }
+
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_CLOYSTER) {
+            Level(44);
+            HP(68); 
+            Item(ITEM_SITRUS_BERRY); 
+            Nature(NATURE_ADAMANT);
+            Ability(ABILITY_SHELL_ARMOR);
+            Moves(MOVE_DETECT, MOVE_RAZOR_SHELL, MOVE_ICICLE_SPEAR, MOVE_ICE_SHARD);
+        }
+        OPPONENT(SPECIES_GLALIE_MEGA) {
+            Level(44);
+            HP(hpVal);
+            Nature(NATURE_JOLLY);
+            Ability(ABILITY_REFRIGERATE);
+            Moves(MOVE_LOW_SWEEP, MOVE_EARTHQUAKE, MOVE_EXPLOSION, MOVE_CRUNCH);
+        }
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_RAZOR_SHELL);
+            EXPECT_MOVE(opponent, hpVal == 1 ? MOVE_LOW_SWEEP : MOVE_LOW_SWEEP);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Currently, shouldConsiderExplosion = false and explosion only move least hits to KO, glalie should pick EQ > crunch based on min damage roll EQ > max damage roll crunch, but in CompareDamagingMoves it sees explosion as least hits to KO, doesn't compare any other moves against each other, and so the final scoring is all other moves = 100, explosion = 90, random between all other moves. This PR fixes this, so the AI only sees explosion in CompareDamagingMoves as a negative effect viable move if ShouldConsiderExplosion = true.

NOTE - this PR also includes the changes for the dynamic typing fix, I will fix that PR up first

## Things to note in the release changelog:
- Bug fix - if the AI sees explosion as the only move with least hits to KO, it will now correctly handle scoring of all other moves depending on ShouldConsiderExplosion instead of picking randomly.

## **Discord contact info**
ghostyboyy97
