### PR TITLE
fix (frostbite): parity with freeze thaw on hit

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5971,7 +5971,7 @@ static void Cmd_moveend(void)
                 && TARGET_TURN_DAMAGED
                 && IsBattlerAlive(gBattlerTarget)
                 && gBattlerAttacker != gBattlerTarget
-                && gMovesInfo[originallyUsedMove].thawsUser
+                && (moveType == TYPE_FIRE || CanBurnHitThaw(gCurrentMove))
                 && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT))
             {
                 gBattleMons[gBattlerTarget].status1 &= ~STATUS1_FROSTBITE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5971,7 +5971,7 @@ static void Cmd_moveend(void)
                 && TARGET_TURN_DAMAGED
                 && IsBattlerAlive(gBattlerTarget)
                 && gBattlerAttacker != gBattlerTarget
-                && (moveType == TYPE_FIRE || CanBurnHitThaw(gCurrentMove))
+                && (moveType == TYPE_FIRE || CanBurnHitThaw(gCurrentMove) || gMovesInfo[originallyUsedMove].thawsUser)
                 && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT))
             {
                 gBattleMons[gBattlerTarget].status1 &= ~STATUS1_FROSTBITE;

--- a/test/battle/status1/frostbite.c
+++ b/test/battle/status1/frostbite.c
@@ -39,7 +39,7 @@ SINGLE_BATTLE_TEST("Frostbite deals 1/16th (Gen7+) or 1/8th damage to affected p
    } THEN { EXPECT_EQ(frostbiteDamage, opponent->maxHP / ((B_BURN_DAMAGE >= GEN_7) ? 16 : 8)); }
 }
 
-SINGLE_BATTLE_TEST("Frostbite is healed if hit with a thawing move")
+SINGLE_BATTLE_TEST("Frostbite is healed if hit with a thawing move (fire type or has burn effect)")
 {
     u32 move;
 
@@ -56,13 +56,7 @@ SINGLE_BATTLE_TEST("Frostbite is healed if hit with a thawing move")
         TURN { MOVE(player, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, player);
-        if (move == MOVE_EMBER) {
-            NONE_OF {
-                MESSAGE("Foe Wobbuffet's frostbite was healed!");
-            }
-        } else {
-            MESSAGE("Foe Wobbuffet's frostbite was healed!");
-        }
+        MESSAGE("Foe Wobbuffet's frostbite was healed!");
    }
 }
 
@@ -75,6 +69,7 @@ SINGLE_BATTLE_TEST("Frostbite is healed when the user uses a thawing move")
     PARAMETRIZE { move = MOVE_FLARE_BLITZ; }
     PARAMETRIZE { move = MOVE_FUSION_FLARE; }
     PARAMETRIZE { move = MOVE_EMBER; }
+    PARAMETRIZE { move = MOVE_SCALD; }
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_FROSTBITE); }


### PR DESCRIPTION
## Description
Fire-type damaging moves and damaging moves that have a burn secondary effect now remove frostbite from an opposing Pokemon, matching how those moves versus freeze is handled in vanilla.

## Things to note in the release changelog:
- If a Pokemon is afflicted with frostbite, hitting it with a damaging Fire-type move or damaging move with a burn chance will remove frostbite from that Pokemon. 

## **Discord contact info**
ghostyboyy97
