### PR TITLE
fix (AI scoring): AI only sees atk/spatk drop on target as beneficial effect if player has move of that category

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -379,7 +379,7 @@ struct AiLogicData
     u8 weatherHasEffect:1; // The same as WEATHER_HAS_EFFECT. Stored here, so it's called only once.
     u8 ejectButtonSwitch:1; // Tracks whether current switch out was from Eject Button
     u8 ejectPackSwitch:1; // Tracks whether current switch out was from Eject Pack
-    u8 shouldConsiderExpolsion:1;
+    u8 shouldConsiderExplosion:1;
     u8 padding:4;
     u8 shouldSwitch; // Stores result of ShouldSwitch, which decides whether a mon should be switched out
     u8 aiCalcInProgress:1;

--- a/include/battle_ai_main.h
+++ b/include/battle_ai_main.h
@@ -112,6 +112,7 @@ void Ai_UpdateSwitchInData(u32 battler);
 void Ai_UpdateFaintData(u32 battler);
 void SetAiLogicDataForTurn(struct AiLogicData *aiData);
 void ResetDynamicAiFunc(void);
+u32 GetStatBeingLoweredFromMoveEffect(u32 statChange);
 
 extern u8 sBattler_AI;
 

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4801,14 +4801,20 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
                     if (!ShouldLowerSpeed(battlerAtk, battlerDef, aiData->abilities[battlerDef]))
                         break;
                 case MOVE_EFFECT_ATK_MINUS_1:
-                case MOVE_EFFECT_DEF_MINUS_1:
+                case MOVE_EFFECT_ATK_MINUS_2:
+                    if (ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)) && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
+                        ADJUST_SCORE(DECENT_EFFECT);
+                    break;
                 case MOVE_EFFECT_SP_ATK_MINUS_1:
+                case MOVE_EFFECT_SP_ATK_MINUS_2:
+                    if (ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)) && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
+                        ADJUST_SCORE(DECENT_EFFECT);
+                    break;
+                case MOVE_EFFECT_DEF_MINUS_1:
                 case MOVE_EFFECT_SP_DEF_MINUS_1:
                 case MOVE_EFFECT_ACC_MINUS_1:
                 case MOVE_EFFECT_EVS_MINUS_1:
-                case MOVE_EFFECT_ATK_MINUS_2:
                 case MOVE_EFFECT_DEF_MINUS_2:
-                case MOVE_EFFECT_SP_ATK_MINUS_2:
                 case MOVE_EFFECT_SP_DEF_MINUS_2:
                 case MOVE_EFFECT_ACC_MINUS_2:
                 case MOVE_EFFECT_EVS_MINUS_2:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4802,12 +4802,12 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
                         break;
                 case MOVE_EFFECT_ATK_MINUS_1:
                 case MOVE_EFFECT_ATK_MINUS_2:
-                    if (ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)) && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
+                    if (ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], STAT_ATK) && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
                         ADJUST_SCORE(DECENT_EFFECT);
                     break;
                 case MOVE_EFFECT_SP_ATK_MINUS_1:
                 case MOVE_EFFECT_SP_ATK_MINUS_2:
-                    if (ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)) && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
+                    if (ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], STAT_SPATK) && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
                         ADJUST_SCORE(DECENT_EFFECT);
                     break;
                 case MOVE_EFFECT_DEF_MINUS_1:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3397,7 +3397,7 @@ static void AI_CompareDamagingMoves(u32 battlerAtk, u32 battlerDef)
     }
 }
 
-static u32 GetStatBeingLoweredFromMoveEffect(u32 statChange)
+u32 GetStatBeingLoweredFromMoveEffect(u32 statChange)
 {
     switch(statChange)
     {

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -497,7 +497,7 @@ static u32 ChooseMoveOrAction_Singles(u32 battlerAi)
     s32 i;
     u32 flags = AI_THINKING_STRUCT->aiFlags[battlerAi];
     u32 opposingBattler = GetBattlerAtPosition(BATTLE_OPPOSITE(GetBattlerPosition(battlerAi)));
-    AI_DATA->shouldConsiderExpolsion = AI_RandLessThan(GetAIExplosionChanceFromHP(AI_DATA->hpPercents[battlerAi]));
+    AI_DATA->shouldConsiderExplosion = AI_RandLessThan(GetAIExplosionChanceFromHP(AI_DATA->hpPercents[battlerAi]));
 
     AI_THINKING_STRUCT->aiLogicId = 0;
     AI_THINKING_STRUCT->movesetIndex = 0;
@@ -995,7 +995,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-20);
             break;
         case EFFECT_EXPLOSION:
-            if(!aiData->shouldConsiderExpolsion)
+            if(!aiData->shouldConsiderExplosion)
             {
                 ADJUST_SCORE(-10);
             }
@@ -2634,7 +2634,7 @@ static s32 AI_TryToFaint(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     // we get a random number based on the remaining HP of the AI attacker
     bool8 canIgnoreExplosionEffect = ((gMovesInfo[move].effect != EFFECT_EXPLOSION)
                                     || (gMovesInfo[move].effect == EFFECT_EXPLOSION
-                                        && AI_DATA->shouldConsiderExpolsion));
+                                        && AI_DATA->shouldConsiderExplosion));
 
     if (CanIndexMoveFaintTarget(battlerAtk, battlerDef, movesetIndex, AI_ATTACKING_ON_FIELD) && canIgnoreExplosionEffect)
     {
@@ -3217,7 +3217,7 @@ static void AI_CompareDamagingMoves(u32 battlerAtk, u32 battlerDef)
                     tempMoveScores[i] = 0;
                     isTwoTurnNotSemiInvulnerableMove[i] = FALSE;
                 }
-                else if (gMovesInfo[moves[i]].effect == EFFECT_EXPLOSION && AI_DATA->shouldConsiderExpolsion == FALSE){
+                else if (gMovesInfo[moves[i]].effect == EFFECT_EXPLOSION && AI_DATA->shouldConsiderExplosion == FALSE){
                     noOfHits[i] = -1;
                     tempMoveScores[i] = 0;
                 }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -961,11 +961,11 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                         return TRUE;
                     break;
                 case MOVE_EFFECT_ATK_MINUS_1:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_1)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
                         return TRUE;
                     break;
                 case MOVE_EFFECT_SP_ATK_MINUS_1:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_1)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_SPATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
                         return TRUE;
                     break;
                 case MOVE_EFFECT_DEF_MINUS_1:
@@ -973,15 +973,15 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                 case MOVE_EFFECT_SP_DEF_MINUS_1:
                 case MOVE_EFFECT_ACC_MINUS_1:
                 case MOVE_EFFECT_EVS_MINUS_1:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_1)) && noOfHitsToKo != 1)
+                    if (ShouldLowerStat(battlerDef, abilityDef, GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
                 case MOVE_EFFECT_ATK_MINUS_2:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_2)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
                         return TRUE;
                     break;
                 case MOVE_EFFECT_SP_ATK_MINUS_2:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_2)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_SPATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
                         return TRUE;
                     break;
                 case MOVE_EFFECT_DEF_MINUS_2:
@@ -989,7 +989,7 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                 case MOVE_EFFECT_SP_DEF_MINUS_2:
                 case MOVE_EFFECT_ACC_MINUS_2:
                 case MOVE_EFFECT_EVS_MINUS_2:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_2)) && noOfHitsToKo != 1)
+                    if (ShouldLowerStat(battlerDef, abilityDef, GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
             }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -961,9 +961,15 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                         return TRUE;
                     break;
                 case MOVE_EFFECT_ATK_MINUS_1:
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_1)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
+                        return TRUE;
+                    break;
+                case MOVE_EFFECT_SP_ATK_MINUS_1:
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_1)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
+                        return TRUE;
+                    break;
                 case MOVE_EFFECT_DEF_MINUS_1:
                 case MOVE_EFFECT_SPD_MINUS_1:
-                case MOVE_EFFECT_SP_ATK_MINUS_1:
                 case MOVE_EFFECT_SP_DEF_MINUS_1:
                 case MOVE_EFFECT_ACC_MINUS_1:
                 case MOVE_EFFECT_EVS_MINUS_1:
@@ -971,9 +977,15 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                         return TRUE;
                     break;
                 case MOVE_EFFECT_ATK_MINUS_2:
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_2)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
+                        return TRUE;
+                    break;
+                case MOVE_EFFECT_SP_ATK_MINUS_2:
+                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK + (gMovesInfo[move].additionalEffects[i].moveEffect - MOVE_EFFECT_ATK_MINUS_2)) && noOfHitsToKo != 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
+                        return TRUE;
+                    break;
                 case MOVE_EFFECT_DEF_MINUS_2:
                 case MOVE_EFFECT_SPD_MINUS_2:
-                case MOVE_EFFECT_SP_ATK_MINUS_2:
                 case MOVE_EFFECT_SP_DEF_MINUS_2:
                 case MOVE_EFFECT_ACC_MINUS_2:
                 case MOVE_EFFECT_EVS_MINUS_2:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -961,10 +961,12 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                         return TRUE;
                     break;
                 case MOVE_EFFECT_ATK_MINUS_1:
+                case MOVE_EFFECT_ATK_MINUS_2:
                     if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
                         return TRUE;
                     break;
                 case MOVE_EFFECT_SP_ATK_MINUS_1:
+                case MOVE_EFFECT_SP_ATK_MINUS_2:
                     if (ShouldLowerStat(battlerDef, abilityDef, STAT_SPATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
                         return TRUE;
                     break;
@@ -973,17 +975,6 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                 case MOVE_EFFECT_SP_DEF_MINUS_1:
                 case MOVE_EFFECT_ACC_MINUS_1:
                 case MOVE_EFFECT_EVS_MINUS_1:
-                    if (ShouldLowerStat(battlerDef, abilityDef, GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)) && noOfHitsToKo > 1)
-                        return TRUE;
-                    break;
-                case MOVE_EFFECT_ATK_MINUS_2:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_ATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
-                        return TRUE;
-                    break;
-                case MOVE_EFFECT_SP_ATK_MINUS_2:
-                    if (ShouldLowerStat(battlerDef, abilityDef, STAT_SPATK) && noOfHitsToKo > 1 && HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
-                        return TRUE;
-                    break;
                 case MOVE_EFFECT_DEF_MINUS_2:
                 case MOVE_EFFECT_SPD_MINUS_2:
                 case MOVE_EFFECT_SP_DEF_MINUS_2:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1038,7 +1038,7 @@ static bool32 AI_IsMoveEffectInMinus(u32 battlerAtk, u32 battlerDef, u32 move, s
                     case MOVE_EFFECT_ATK_DEF_DOWN:
                     case MOVE_EFFECT_DEF_SPDEF_DOWN:
                         if ((gMovesInfo[move].additionalEffects[i].self && abilityAtk != ABILITY_CONTRARY && abilityAtk != ABILITY_BAD_COMPANY)
-                            || (noOfHitsToKo != 1 && abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move)))
+                            || (noOfHitsToKo > 1 && abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move)))
                             return TRUE;
                         break;
                     case MOVE_EFFECT_RECHARGE:
@@ -1059,7 +1059,7 @@ static bool32 AI_IsMoveEffectInMinus(u32 battlerAtk, u32 battlerDef, u32 move, s
                     case MOVE_EFFECT_ACC_PLUS_2:
                     case MOVE_EFFECT_ALL_STATS_UP:
                         if ((gMovesInfo[move].additionalEffects[i].self && abilityAtk == ABILITY_CONTRARY)
-                            || (noOfHitsToKo != 1 && !(abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move))))
+                            || (noOfHitsToKo > 1 && !(abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move))))
                             return TRUE;
                         break;
                 }

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -178,7 +178,6 @@ AI_SINGLE_BATTLE_TEST("Guaranteed secondary effect - AI should care about player
         PLAYER(SPECIES_RUNERIGUS){
             Level(59);
             Speed(5);
-            // no item
             Nature(NATURE_RELAXED);
             Ability(ABILITY_SHADOW_SHIELD);
             Moves(MOVE_EARTHQUAKE, MOVE_SCARY_FACE);
@@ -188,11 +187,8 @@ AI_SINGLE_BATTLE_TEST("Guaranteed secondary effect - AI should care about player
             Speed(10);
             Item(ITEM_BOOSTER_ENERGY);
             Nature(NATURE_JOLLY);
-            // ability should default to quark drive
             Moves(MOVE_CLOSE_COMBAT, MOVE_SPIRIT_BREAK, MOVE_BULK_UP, MOVE_KNOCK_OFF);
         }
-        // previously - spirit break +3 most damaging move (w/ plus effect) and guaranteed effect +2 vs knock off +0 (neutral dmg move) and bulk up +2
-        // now - player slow 3hko vs AI - knock off/spirit break +1 neutral effect damaging moves, bulk up +2 shouldSetup = true
     } WHEN {
         TURN{
             MOVE(player, MOVE_SCARY_FACE);
@@ -207,7 +203,6 @@ AI_SINGLE_BATTLE_TEST("Guaranteed secondary effect - AI should care about player
         PLAYER(SPECIES_RUNERIGUS){
             Level(59);
             Speed(5);
-            // no item
             Nature(NATURE_RELAXED);
             Ability(ABILITY_SHADOW_SHIELD);
             Moves(MOVE_SHADOW_BALL, MOVE_SCARY_FACE);
@@ -217,15 +212,37 @@ AI_SINGLE_BATTLE_TEST("Guaranteed secondary effect - AI should care about player
             Speed(10);
             Item(ITEM_BOOSTER_ENERGY);
             Nature(NATURE_JOLLY);
-            // ability should default to quark drive
             Moves(MOVE_CLOSE_COMBAT, MOVE_LUNGE, MOVE_BULK_UP, MOVE_KNOCK_OFF);
         }
-        // previously - spirit break +3 most damaging move (w/ plus effect) and guaranteed effect +2 vs knock off +0 (neutral dmg move) and bulk up +2
-        // now - player slow 3hko vs AI - knock off/spirit break +1 neutral effect damaging moves, bulk up +2 shouldSetup = true
     } WHEN {
         TURN{
             MOVE(player, MOVE_SCARY_FACE);
             EXPECT_MOVE(opponent, MOVE_BULK_UP);
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("MoveEffectInPlus - AI prefers stat drop to neutral move in 2+HKO cases"){
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_RUNERIGUS){
+            Level(59);
+            Speed(5);
+            Nature(NATURE_RELAXED);
+            Ability(ABILITY_SHADOW_SHIELD);
+            Moves(MOVE_SHADOW_BALL, MOVE_SCARY_FACE);
+        }
+        OPPONENT(SPECIES_IRON_VALIANT){
+            Level(59);
+            Speed(10);
+            Item(ITEM_BOOSTER_ENERGY);
+            Nature(NATURE_JOLLY);
+            Moves(MOVE_LIQUIDATION, MOVE_AQUA_TAIL);
+        }
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_SCARY_FACE);
+            EXPECT_MOVE(opponent, MOVE_LIQUIDATION);
         }
     }
 }

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -171,3 +171,61 @@ AI_SINGLE_BATTLE_TEST("Explosion interaction - glalie should correctly score cru
         }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("Guaranteed secondary effect - AI should care about player's moveset for attack and special attack drops (spatk drop vs atk only set)"){
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_RUNERIGUS){
+            Level(59);
+            Speed(5);
+            // no item
+            Nature(NATURE_RELAXED);
+            Ability(ABILITY_SHADOW_SHIELD);
+            Moves(MOVE_EARTHQUAKE, MOVE_SCARY_FACE);
+        }
+        OPPONENT(SPECIES_IRON_VALIANT){
+            Level(59);
+            Speed(10);
+            Item(ITEM_BOOSTER_ENERGY);
+            Nature(NATURE_JOLLY);
+            // ability should default to quark drive
+            Moves(MOVE_CLOSE_COMBAT, MOVE_SPIRIT_BREAK, MOVE_BULK_UP, MOVE_KNOCK_OFF);
+        }
+        // previously - spirit break +3 most damaging move (w/ plus effect) and guaranteed effect +2 vs knock off +0 (neutral dmg move) and bulk up +2
+        // now - player slow 3hko vs AI - knock off/spirit break +1 neutral effect damaging moves, bulk up +2 shouldSetup = true
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_SCARY_FACE);
+            EXPECT_MOVE(opponent, MOVE_BULK_UP);
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("Guaranteed secondary effect - AI should care about player's moveset for attack and special attack drops (atk drop vs spatk only set)"){
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_RUNERIGUS){
+            Level(59);
+            Speed(5);
+            // no item
+            Nature(NATURE_RELAXED);
+            Ability(ABILITY_SHADOW_SHIELD);
+            Moves(MOVE_SHADOW_BALL, MOVE_SCARY_FACE);
+        }
+        OPPONENT(SPECIES_IRON_VALIANT){
+            Level(59);
+            Speed(10);
+            Item(ITEM_BOOSTER_ENERGY);
+            Nature(NATURE_JOLLY);
+            // ability should default to quark drive
+            Moves(MOVE_CLOSE_COMBAT, MOVE_LUNGE, MOVE_BULK_UP, MOVE_KNOCK_OFF);
+        }
+        // previously - spirit break +3 most damaging move (w/ plus effect) and guaranteed effect +2 vs knock off +0 (neutral dmg move) and bulk up +2
+        // now - player slow 3hko vs AI - knock off/spirit break +1 neutral effect damaging moves, bulk up +2 shouldSetup = true
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_SCARY_FACE);
+            EXPECT_MOVE(opponent, MOVE_BULK_UP);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Previously, the AI would see moves with a guaranteed attack/special attack drop as a beneficial secondary effect if the player had no moves of that type (e.g. Spirit Break got +2 to its score from AI_CalcMoveEffectScore --> guaranteed effects conditional even if the player's move set was entirely physical moves). Now, attack/special attack drops in both the AI_CalcMoveEffectScore guaranteed effects conditional and the AI_IsMoveEffectInPlus move comparison conditional only get that boost if the player has relevant moves it would affect.

## Things to note in the release changelog:
- The AI now scores moves that would drop the player's Attack or Special Attack stat considering if the player has any physical or special moves respectively.

## **Discord contact info**
ghostyboyy97
