### PR TITLE
fix (AI scoring): shield dust interactions, IsMoveEffectInMinus self effect fixes

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -149,6 +149,7 @@ bool32 IsAffectedByPowder(u32 battler, u32 ability, u32 holdEffect);
 bool32 MovesWithCategoryUnusable(u32 attacker, u32 target, u32 category);
 enum MoveComparisonResult AI_WhichMoveBetter(u32 move1, u32 move2, u32 battlerAtk, u32 battlerDef, s32 noOfHitsToKo);
 struct SimulatedDamage AI_CalcDamageSaveBattlers(u32 move, u32 battlerAtk, u32 battlerDef, uq4_12_t *typeEffectiveness, bool32 considerZPower);
+bool32 IsAdditionalEffectBlocked(u32 battlerAtk, u32 abilityAtk, u32 battlerDef, u32 abilityDef);
 struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, uq4_12_t *typeEffectiveness, bool32 considerZPower, u32 weather);
 bool32 AI_IsDamagedByRecoil(u32 battler, bool8 considerRockHead);
 u32 GetNoOfHitsToKO(u32 dmg, s32 hp);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4791,6 +4791,9 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         }
         else // consider move effects that hinder the target
         {
+            if (IsAdditionalEffectBlocked(battlerAtk, aiData->abilities[battlerAtk], battlerDef, aiData->abilities[battlerDef]))
+                continue;
+
             switch (gMovesInfo[move].additionalEffects[i].moveEffect)
             {
                 case MOVE_EFFECT_FLINCH:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -548,6 +548,17 @@ bool32 IsDamageMoveUnusable(u32 battlerAtk, u32 battlerDef, u32 move, u32 moveTy
     return FALSE;
 }
 
+bool32 IsAdditionalEffectBlocked(u32 battlerAtk, u32 abilityAtk, u32 battlerDef, u32 abilityDef)
+{
+    if (AI_DATA->holdEffects[battlerDef] == HOLD_EFFECT_COVERT_CLOAK)
+        return TRUE;
+
+    if (abilityDef == ABILITY_SHIELD_DUST && !IsMoldBreakerTypeAbility(battlerAtk, abilityAtk))
+        return TRUE;
+
+    return FALSE;
+}
+
 static inline s32 GetDamageByRollType(s32 dmg, enum DamageRollType rollType)
 {
     if (rollType == DMG_ROLL_LOWEST)
@@ -933,6 +944,9 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
         }
         else // consider move effects that hinder the target
         {
+            if (IsAdditionalEffectBlocked(battlerAtk, abilityAtk, battlerDef, abilityDef))
+                continue;
+
             switch (gMovesInfo[move].additionalEffects[i].moveEffect)
             {
                 case MOVE_EFFECT_POISON:
@@ -1035,8 +1049,8 @@ static bool32 AI_IsMoveEffectInMinus(u32 battlerAtk, u32 battlerDef, u32 move, s
                     case MOVE_EFFECT_ATK_DEF_DOWN:
                     case MOVE_EFFECT_DEF_SPDEF_DOWN:
                         if ((gMovesInfo[move].additionalEffects[i].self && abilityAtk != ABILITY_CONTRARY && abilityAtk != ABILITY_BAD_COMPANY)
-                            || (noOfHitsToKo != 1 && abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move)))
-                            return TRUE;
+                            || (noOfHitsToKo != 1 && !gMovesInfo[move].additionalEffects[i].self && abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move)))
+                                return TRUE;
                         break;
                     case MOVE_EFFECT_RECHARGE:
                         return gMovesInfo[move].additionalEffects[i].self;
@@ -1056,8 +1070,8 @@ static bool32 AI_IsMoveEffectInMinus(u32 battlerAtk, u32 battlerDef, u32 move, s
                     case MOVE_EFFECT_ACC_PLUS_2:
                     case MOVE_EFFECT_ALL_STATS_UP:
                         if ((gMovesInfo[move].additionalEffects[i].self && abilityAtk == ABILITY_CONTRARY)
-                            || (noOfHitsToKo != 1 && !(abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move))))
-                            return TRUE;
+                            || (noOfHitsToKo != 1 && !gMovesInfo[move].additionalEffects[i].self && !(abilityDef == ABILITY_CONTRARY && !DoesBattlerIgnoreAbilityChecks(abilityAtk, move))))
+                                return TRUE;
                         break;
                 }
             }

--- a/test/battle/ability/shield_dust.c
+++ b/test/battle/ability/shield_dust.c
@@ -176,3 +176,31 @@ SINGLE_BATTLE_TEST("Shield Dust does not prevent ability stat changes")
         MESSAGE("Vivillon's Speed fell!");
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI will score secondary effects against shield dust correctly")
+{
+    AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+    GIVEN {
+        PLAYER(SPECIES_DUSTOX){ Ability(ABILITY_SHIELD_DUST); Moves(MOVE_GUST); }
+        OPPONENT(SPECIES_SUNFLORA){ Ability(ABILITY_EARLY_BIRD); Moves(MOVE_MYSTICAL_FIRE, MOVE_FIERY_DANCE); }
+    } WHEN {
+        TURN {
+            MOVE(player, MOVE_GUST);
+            EXPECT_MOVE(opponent, MOVE_FIERY_DANCE);
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI will score secondary effects against shield dust correctly when it has Mold Breaker")
+{
+    AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+    GIVEN {
+        PLAYER(SPECIES_DUSTOX){ Ability(ABILITY_SHIELD_DUST); Moves(MOVE_GUST); }
+        OPPONENT(SPECIES_SUNFLORA){ Ability(ABILITY_MOLD_BREAKER); Moves(MOVE_MYSTICAL_FIRE, MOVE_FIERY_DANCE); }
+    } WHEN {
+        TURN {
+            MOVE(player, MOVE_GUST);
+            EXPECT_MOVE(opponent, MOVE_MYSTICAL_FIRE);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes a couple small issues with AI scoring.
1. AI previously did not see Shield Dust when evaluating secondary guaranteed or chances for effects on a target, and would score as if the ability did not exist.
2. AI previously would see - if the AI didn't have Mold Breaker, if a damage move like Metal Claw had a random chance positive self-buff, and the target didn't have Contrary - that it was a negative effect incorrectly, and so would prefer a neutral move over Metal Claw with equal hits/ranges to KO. (e.g. in the new test cases added, the first one would fail at MoveEffectInMinus preferring neutral Mystical Fire over negative Fiery Dance; now scores correctly positive Fiery Dance over neutral Mystical fire).

## **People who collaborated with me in this PR**
@AlexOn1ine (collaborated upstream - https://github.com/rh-hideout/pokeemerald-expansion/pull/8126 )

## Things to note in the release changelog:
- The AI now sees Shield Dust on the player's Pokemon correctly
- The AI now sees self-targeted positive effect boosts correctly


## **Discord contact info**
ghostyboyy97
