### PR TITLE
fix (contrary): moveEffectInPlus now sees self-targeted negative effects when contrary as positive

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -926,6 +926,14 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
                     if (abilityAtk == ABILITY_CONTRARY && BattlerStatCanRise(battlerAtk, abilityAtk, GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)))
                         return TRUE;
                     break;
+                case MOVE_EFFECT_ATK_DEF_DOWN:
+                    if (abilityAtk == ABILITY_CONTRARY && (BattlerStatCanRise(battlerAtk, abilityAtk, STAT_ATK) || BattlerStatCanRise(battlerAtk, abilityAtk, STAT_DEF)))
+                        return TRUE;
+                    break;
+                case MOVE_EFFECT_DEF_SPDEF_DOWN:
+                    if (abilityAtk == ABILITY_CONTRARY && (BattlerStatCanRise(battlerAtk, abilityAtk, STAT_DEF) || BattlerStatCanRise(battlerAtk, abilityAtk, STAT_SPDEF)))
+                        return TRUE;
+                    break;
                 case MOVE_EFFECT_ATK_PLUS_1:
                 case MOVE_EFFECT_ATK_PLUS_2:
                     if (BattlerStatCanRise(battlerAtk, abilityAtk, STAT_ATK))

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -903,6 +903,29 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
         {
             switch (gMovesInfo[move].additionalEffects[i].moveEffect)
             {
+                case MOVE_EFFECT_ATK_MINUS_1:
+                case MOVE_EFFECT_ATK_MINUS_2:
+                    if (abilityAtk == ABILITY_CONTRARY && HasMoveWithCategory(battlerAtk, DAMAGE_CATEGORY_PHYSICAL) && BattlerStatCanRise(battlerAtk, abilityAtk, STAT_ATK))
+                        return TRUE;
+                    break;
+                case MOVE_EFFECT_SP_ATK_MINUS_1:
+                case MOVE_EFFECT_SP_ATK_MINUS_2:
+                    if (abilityAtk == ABILITY_CONTRARY && HasMoveWithCategory(battlerAtk, DAMAGE_CATEGORY_SPECIAL) && BattlerStatCanRise(battlerAtk, abilityAtk, STAT_SPATK))
+                        return TRUE;
+                    break;
+                case MOVE_EFFECT_DEF_MINUS_1:
+                case MOVE_EFFECT_SPD_MINUS_1:
+                case MOVE_EFFECT_SP_DEF_MINUS_1:
+                case MOVE_EFFECT_ACC_MINUS_1:
+                case MOVE_EFFECT_EVS_MINUS_1:
+                case MOVE_EFFECT_DEF_MINUS_2:
+                case MOVE_EFFECT_SPD_MINUS_2:
+                case MOVE_EFFECT_SP_DEF_MINUS_2:
+                case MOVE_EFFECT_ACC_MINUS_2:
+                case MOVE_EFFECT_EVS_MINUS_2:
+                    if (abilityAtk == ABILITY_CONTRARY && BattlerStatCanRise(battlerAtk, abilityAtk, GetStatBeingLoweredFromMoveEffect(gMovesInfo[move].additionalEffects[i].moveEffect)))
+                        return TRUE;
+                    break;
                 case MOVE_EFFECT_ATK_PLUS_1:
                 case MOVE_EFFECT_ATK_PLUS_2:
                     if (BattlerStatCanRise(battlerAtk, abilityAtk, STAT_ATK))

--- a/test/battle/ability/contrary.c
+++ b/test/battle/ability/contrary.c
@@ -241,3 +241,31 @@ SINGLE_BATTLE_TEST("Sticky Web raises Speed by 1 for Contrary mon on switch-in")
         MESSAGE("Foe Snivy's Speed rose!");
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI sees contrary-effected moves correctly in MoveEffectInPlus")
+{
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_HERACROSS){
+            Level(44);
+            HP(1);
+            Speed(5);
+            Nature(NATURE_ADAMANT);
+            Item(ITEM_LOADED_DICE);
+            Moves(MOVE_PIN_MISSILE);
+        }
+        OPPONENT(SPECIES_SERPERIOR){
+            Level(44);
+            Speed(10);
+            Item(ITEM_FOCUS_SASH);
+            Nature(NATURE_TIMID);
+            Ability(ABILITY_CONTRARY);
+            Moves(MOVE_LEAF_STORM, MOVE_DRAGON_PULSE, MOVE_HIDDEN_POWER, MOVE_GLARE);
+        }
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_PIN_MISSILE);
+            EXPECT_MOVE(opponent, MOVE_LEAF_STORM); // previously all damaging moves 107, now scores leaf storm 107 vs other attacks 106
+        }
+    }
+}


### PR DESCRIPTION
## Description
Previously, Pokemon with Contrary would not see self-targeted stat drop secondary effects as positive effects in MoveEffectInPlus. Now, if damage move comparison reaches that step, MoveEffectInPlus will correctly evaluate the ability and secondary effect interaction. 

Issue reported by Whybona - instead of 100% Leaf Storm as a positive effect, it was 50/50 between Leaf Storm/Dragon Pulse all neutral effects. https://discord.com/channels/1303930187976802374/1333124109436981320/1436374325845426367

## Things to note in the release changelog:
- When comparing positive move effects in damaging move comparison, the AI will correctly see moves like Leaf Storm as beneficial if their Pokemon has Contrary.

## **Discord contact info**
ghostyboyy97
