### PR TITLE
fix (AI): HasMoveToStopSetup should correctly check self flag when looking at speed drop moves, and fix numAdditionalEffects handling

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2331,7 +2331,7 @@ bool32 HasBattlerSideUsedMoveWithAdditionalEffect(u32 battler, u32 moveEffect)
 
 bool32 HasMoveToStopSetup(u32 battlerId, u32 noOfHitsToFaint, u32 aiIsFaster)
 {
-    s32 i;
+    s32 i, j;
     u16 *moves = GetMovesArray(battlerId);
 
     for (i = 0; i < MAX_MON_MOVES; i++)
@@ -2343,12 +2343,15 @@ bool32 HasMoveToStopSetup(u32 battlerId, u32 noOfHitsToFaint, u32 aiIsFaster)
                 if (GetMovePriority(battlerId, moves[i]) > 0)
                     return TRUE;
 
-                switch (gMovesInfo[moves[i]].additionalEffects[i].moveEffect)
+                for (j = 0; j < gMovesInfo[moves[i]].numAdditionalEffects; j++)
                 {
-                    case MOVE_EFFECT_SPD_MINUS_1:
-                    case MOVE_EFFECT_SPD_MINUS_2:
-                        if(aiIsFaster)
-                            return TRUE;
+                    switch (gMovesInfo[moves[i]].additionalEffects[j].moveEffect)
+                    {
+                        case MOVE_EFFECT_SPD_MINUS_1:
+                        case MOVE_EFFECT_SPD_MINUS_2:
+                            if (aiIsFaster && !gMovesInfo[moves[i]].additionalEffects[j].self)
+                                return TRUE;
+                    }
                 }
             }
         }

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -246,3 +246,34 @@ AI_SINGLE_BATTLE_TEST("MoveEffectInPlus - AI prefers stat drop to neutral move i
         }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("HasMoveToStopSetup - AI should not see self-targeted speed drops as preventing setup moves in 2hko cases"){
+    u16 move;
+    PARAMETRIZE { move = MOVE_EARTHQUAKE; }
+    PARAMETRIZE { move = MOVE_BULLDOZE; }
+
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_RHYDON){
+            Level(100);
+            Nature(NATURE_ADAMANT);
+            Item(ITEM_EVIOLITE);
+            Speed(1);
+            Ability(ABILITY_LIGHTNING_ROD);
+            Moves(MOVE_HAMMER_ARM, move);
+        }
+        OPPONENT(SPECIES_GRIMMSNARL){
+            Level(100);
+            Nature(NATURE_JOLLY);
+            Ability(ABILITY_INFILTRATOR);
+            Speed(2);
+            HP(331);
+            Moves(MOVE_NASTY_PLOT, MOVE_AURA_SPHERE);
+        }
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_HAMMER_ARM);
+            EXPECT_MOVE(opponent, move == MOVE_EARTHQUAKE ? MOVE_NASTY_PLOT : MOVE_AURA_SPHERE);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Previously, AI would see that self-speed drop moves like Hammer Arm would trigger HasMoveToStopSetup(), and was reusing the i index for grabbing additional effects. This fix creates a new index to iterate through all possible additional effects on a move, and prevents the AI from recognizing speed drops from Hammer Arm like move incorrectly.

## Images
Calc screenshot of the test scenario below. When the second move is Earthquake, both moves 2hko and the AI should go for Nasty Plot. When the second move is Bulldoze, with a slow 2HKO and a speed dropping move, the AI should not be able to setup and instead use Aura Sphere.

<img width="1133" height="1075" alt="Screenshot_467" src="https://github.com/user-attachments/assets/797032c2-b650-425b-8eea-229f22d3c3ab" />

## **People who collaborated with me in this PR**
@MaximeGr00

## Things to note in the release changelog:
- AI will no longer incorrectly evaluate self-speed dropping moves like Hammer Arm incorrectly when checking if speed drop moves should prevent setup.

## **Discord contact info**
ghostyboyy97
