### PR TITLE
ghosty used rapid spin! ghosty blew away the semicolon!

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4918,7 +4918,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
                     break;
                 case MOVE_EFFECT_STEALTH_ROCK:
                 case MOVE_EFFECT_SPIKES:
-                    if (AI_ShouldSetUpHazards(battlerAtk, battlerDef, aiData));
+                    if (AI_ShouldSetUpHazards(battlerAtk, battlerDef, aiData))
                     {
                         if (gDisableStructs[battlerAtk].isFirstTurn)
                             ADJUST_SCORE(BEST_EFFECT);

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -277,3 +277,32 @@ AI_SINGLE_BATTLE_TEST("HasMoveToStopSetup - AI should not see self-targeted spee
         }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("Rapid Spin should prevent secondary hazard effect moves from getting a setup score boost")
+{
+
+    GIVEN{
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_BLASTOISE){
+            Level(56);
+            Nature(NATURE_ADAMANT);
+            Ability(ABILITY_TORRENT);
+            Item(ITEM_MYSTIC_WATER);
+            Speed(109);
+            Moves(MOVE_FAKE_OUT, MOVE_FLIP_TURN, MOVE_SCALD, MOVE_RAPID_SPIN);
+        }
+        OPPONENT(SPECIES_KLEAVOR){
+            Level(54);
+            Nature(NATURE_JOLLY);
+            Ability(ABILITY_SHARPNESS);
+            Item(ITEM_FOCUS_SASH);
+            Speed(124);
+            Moves(MOVE_STONE_AXE, MOVE_X_SCISSOR, MOVE_ACCELEROCK, MOVE_NIGHT_SLASH);
+        }
+    } WHEN {
+        TURN{
+            MOVE(player, MOVE_FLIP_TURN);
+            EXPECT_MOVE(opponent, MOVE_X_SCISSOR);
+        }
+    }
+}

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -280,29 +280,14 @@ AI_SINGLE_BATTLE_TEST("HasMoveToStopSetup - AI should not see self-targeted spee
 
 AI_SINGLE_BATTLE_TEST("Rapid Spin should prevent secondary hazard effect moves from getting a setup score boost")
 {
-
-    GIVEN{
+    ASSUME(MoveHasAdditionalEffectSelf(MOVE_STONE_AXE, MOVE_EFFECT_STEALTH_ROCK));
+    ASSUME(MoveHasAdditionalEffectSelf(MOVE_RAPID_SPIN, MOVE_EFFECT_RAPID_SPIN));
+    ASSUME(GetMovePower(MOVE_X_SCISSOR) == 80);
+    GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_BLASTOISE){
-            Level(56);
-            Nature(NATURE_ADAMANT);
-            Ability(ABILITY_TORRENT);
-            Item(ITEM_MYSTIC_WATER);
-            Speed(109);
-            Moves(MOVE_FAKE_OUT, MOVE_FLIP_TURN, MOVE_SCALD, MOVE_RAPID_SPIN);
-        }
-        OPPONENT(SPECIES_KLEAVOR){
-            Level(54);
-            Nature(NATURE_JOLLY);
-            Ability(ABILITY_SHARPNESS);
-            Item(ITEM_FOCUS_SASH);
-            Speed(124);
-            Moves(MOVE_STONE_AXE, MOVE_X_SCISSOR, MOVE_ACCELEROCK, MOVE_NIGHT_SLASH);
-        }
+        PLAYER(SPECIES_BLASTOISE){ Level(56); Nature(NATURE_ADAMANT); Ability(ABILITY_TORRENT); Item(ITEM_MYSTIC_WATER); Speed(109); Moves(MOVE_FAKE_OUT, MOVE_FLIP_TURN, MOVE_SCALD, MOVE_RAPID_SPIN); }
+        OPPONENT(SPECIES_KLEAVOR){ Level(54); Nature(NATURE_JOLLY); Ability(ABILITY_SHARPNESS); Item(ITEM_FOCUS_SASH); Speed(124); Moves(MOVE_STONE_AXE, MOVE_X_SCISSOR, MOVE_ACCELEROCK, MOVE_NIGHT_SLASH); }
     } WHEN {
-        TURN{
-            MOVE(player, MOVE_FLIP_TURN);
-            EXPECT_MOVE(opponent, MOVE_X_SCISSOR);
-        }
+        TURN { MOVE(player, MOVE_FLIP_TURN); EXPECT_MOVE(opponent, MOVE_X_SCISSOR); }
     }
 }


### PR DESCRIPTION
## Description
Removed the nefarious load-bearing semicolon that was allowing the AI to see that Pokemon like Kleavor should get a Stone Axe boost even when the player had Rapid Spin.

## **People who collaborated with me in this PR**
@Pawkkie (eyes like a hawK)

## Things to note in the release changelog:
- The AI now correctly recognizes when the player has Rapid Spin for moves with secondary hazard effects like Stone Axe.

## **Discord contact info**
ghostyboyy97
