### PR TITLE
fix (scoring): AI ignores first turn only and status in CompareMoveSpeeds

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3100,6 +3100,9 @@ static enum MoveComparisonResult CompareMoveAccuracies(u32 battlerAtk, u32 battl
 static enum MoveComparisonResult CompareMoveSpeeds(u32 battlerAtk, u32 battlerDef, u16 move1, u16 move2)
 {
     u32 predictedMove = AI_DATA->lastUsedMove[battlerDef];
+    if (gMovesInfo[predictedMove].effect == EFFECT_FIRST_TURN_ONLY || gMovesInfo[predictedMove].category == DAMAGE_CATEGORY_STATUS)
+        predictedMove = MOVE_NONE;
+
     u32 speed1 = AI_WhoStrikesFirst(battlerAtk, battlerDef, move1, predictedMove, CONSIDER_PRIORITY);
     u32 speed2 = AI_WhoStrikesFirst(battlerAtk, battlerDef, move2, predictedMove, CONSIDER_PRIORITY);
 

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "test/battle.h"
+#include "battle_ai_main.h"
 #include "battle_ai_util.h"
 
 AI_SINGLE_BATTLE_TEST("AI will not further increase Attack / Sp. Atk stat if it knows it faints to target: AI faster")
@@ -291,3 +292,20 @@ AI_SINGLE_BATTLE_TEST("Rapid Spin should prevent secondary hazard effect moves f
         TURN { MOVE(player, MOVE_FLIP_TURN); EXPECT_MOVE(opponent, MOVE_X_SCISSOR); }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("CompareMoveSpeeds should ignore fake out and status moves for AI_CompareDamagingMoves BEST_DAMAGE_MOVE scoring")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_BLAZIKEN){ Level(44); Nature(NATURE_ADAMANT); Ability(ABILITY_STRIKER); Speed(89); HP(20); Moves(MOVE_DETECT, MOVE_TRIPLE_ARROWS); }
+        OPPONENT(SPECIES_KLEAVOR){ Level(43); Nature(NATURE_ADAMANT); Ability(ABILITY_SOLID_ROCK); Speed(80); Moves(MOVE_ICE_PUNCH, MOVE_ACCELEROCK); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_DETECT); EXPECT_MOVE(opponent, MOVE_ACCELEROCK); }
+        TURN { 
+            MOVE(player, MOVE_TRIPLE_ARROWS);
+            SCORE_EQ_VAL(opponent, MOVE_ACCELEROCK, (AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE + FAST_KILL)); 
+            SCORE_EQ_VAL(opponent, MOVE_ICE_PUNCH, (AI_SCORE_DEFAULT + SLOW_KILL)); 
+        }
+    }
+}
+


### PR DESCRIPTION
## Description
Previously, if the predicted move was a first turn only move (like Fake Out) or a status priority move (like Detect), the AI would incorrectly see its priority bracket vs the player in AI_CompareDamagingMoves via CompareMoveSpeeds. This fix 

## Issue(s) that this PR fixes
Fixes #120 

## **People who collaborated with me in this PR**
@Pawkkie wrote the fix upstream, and credits to @MaximeGr00 for helping + silver and myself for finding this issue!

## Things to note in the release changelog:
- The AI will no longer incorrectly see the speed of priority moves when running CompareMoveSpeeds() if you used fake out/detect/protect on the previous turn.

## **Discord contact info**
ghostyboyy97
