### PR TITLE
Move descriptions changes, move scoring changes

### DIFF
--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -58,6 +58,7 @@
 #define SHOULD_RECOVER_CHANCE                                   50 // Chance the AI will give recovery moves score increase if less than ENABLE_RECOVERY_THRESHOLD and in no immediate danger
 #define ENABLE_RECOVERY_THRESHOLD                               60 // HP percentage beneath which SHOULD_RECOVER_CHANCE is active
 #define BOOST_INTO_HAZE_CHANCE                                  0  // Chance the AI will use a stat boosting move if the player has used Haze
+#define CONSIDER_NO_SETUP_HAZARDS_CHANCE                        80 // Chance the AI does not set up hazards if the player has defog, tidy up or rapid spin
 
 #define PRIORITIZE_LAST_CHANCE_CHANCE                           80 // Chance the AI will prioritize Last Chance (priority move in the face of being outsped and KO'd) over Slow KO
 

--- a/include/random.h
+++ b/include/random.h
@@ -194,6 +194,7 @@ enum RandomTag
     RNG_AI_BOOST_INTO_HAZE,
     RNG_AI_PRIORITIZE_LAST_CHANCE,
     RNG_AI_SWITCH_ABSORBING_STAY_IN,
+    RNG_AI_NO_SETUP_HAZARDS,
 };
 
 #define RandomWeighted(tag, ...) \

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1141,7 +1141,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                     ADJUST_SCORE(-10);
                 }
             }    
-            if ((GetBestDmgFromBattler(battlerDef, battlerAtk, AI_DEFENDING_NORMAL)*100/gBattleMons[battlerAtk].maxHP) >= (aiData->hpPercents[battlerAtk]/2)) // if player deals over 50% of AI's current hp 
+            if ((GetBestDmgFromBattler(battlerDef, battlerAtk, AI_DEFENDING_NORMAL)*100/gBattleMons[battlerAtk].maxHP) >= (aiData->hpPercents[battlerAtk]/2) && (aiData->holdEffects[battlerAtk] == HOLD_EFFECT_RESTORE_STATS)) // if player deals over 50% of AI's current hp 
             {
                 ADJUST_SCORE(-10);
             }

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -734,6 +734,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     u32 i;
     u32 weather;
     u32 predictedMove = aiData->lastUsedMove[battlerDef];
+    u32 moveUsed; // stops AI from using the same move multiple times 
 
     if (IS_TARGETING_PARTNER(battlerAtk, battlerDef))
         return score;
@@ -1007,6 +1008,10 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             {
                 ADJUST_SCORE(-10);
             }
+            if (CountUsablePartyMons(battlerAtk) == 0)
+            {
+                ADJUST_SCORE(-10);
+            }   
             break;
     // stat raising effects
         case EFFECT_ATTACK_UP:
@@ -1128,6 +1133,18 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-8);
             break;
         case EFFECT_SHELL_SMASH:
+            for (i = 0; i < MAX_MON_MOVES; i++)
+            {
+                moveUsed = gBattleResources->battleHistory->usedMoves[battlerAtk][i];
+                if (gMovesInfo[moveUsed].effect == EFFECT_SHELL_SMASH)  // if shell smash was used by the AI before 
+                {
+                    ADJUST_SCORE(-10);
+                }
+            }    
+            if ((GetBestDmgFromBattler(battlerDef, battlerAtk, AI_DEFENDING_NORMAL)*100/gBattleMons[battlerAtk].maxHP) >= (aiData->hpPercents[battlerAtk]/2)) // if player deals over 50% of AI's current hp 
+            {
+                ADJUST_SCORE(-10);
+            }
             if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
             {
                 if (!BattlerStatCanRise(battlerAtk, aiData->abilities[battlerAtk], STAT_DEF))
@@ -1143,10 +1160,6 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                     ADJUST_SCORE(-10);
                 else if (!BattlerStatCanRise(battlerAtk, aiData->abilities[battlerAtk], STAT_SPEED))
                     ADJUST_SCORE(-10);
-                else if (gBattleMons[battlerAtk].statStages[STAT_DEF] < (DEFAULT_STAT_STAGE - 2))
-                    ADJUST_SCORE(-4);
-                else if (gBattleMons[battlerAtk].statStages[STAT_SPDEF] < (DEFAULT_STAT_STAGE - 2))
-                    ADJUST_SCORE(-4);
             }
             break;
         case EFFECT_GROWTH:
@@ -2317,6 +2330,22 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
               || PartnerMoveIsSameNoTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
+        case EFFECT_OCTOLOCK:
+            if ((IS_BATTLER_OF_TYPE(battlerDef, TYPE_GHOST) 
+                || aiData->holdEffects[battlerDef] == HOLD_EFFECT_SHED_SHELL) 
+                && (CountUsablePartyMons(battlerDef) != 0))
+            {
+                ADJUST_SCORE(-10);
+            }
+            for (i = 0; i < MAX_MON_MOVES; i++)
+            {
+                moveUsed = gBattleResources->battleHistory->usedMoves[battlerAtk][i];
+                if (gMovesInfo[moveUsed].effect == EFFECT_OCTOLOCK)  // if octolock was used by the AI before 
+                    {
+                        ADJUST_SCORE(-10);
+                    }
+            }  
+            break;
         case EFFECT_FLING:
             if (!CanFling(battlerAtk))
             {
@@ -3451,6 +3480,13 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
     bool32 isDoubleBattle = IsValidDoubleBattle(battlerAtk);
     u32 i;
 
+    // strength sap data 
+    u32 atkStat = gBattleMons[battlerDef].attack;
+    u32 atkStage = gBattleMons[battlerDef].statStages[STAT_ATK];
+    atkStat *= gStatStageRatios[atkStage][0];
+    atkStat /= gStatStageRatios[atkStage][1];
+    u32 healPercent = atkStat * 100 / gBattleMons[battlerAtk].maxHP;
+
     // The AI should understand that while Dynamaxed, status moves function like Protect.
     if (GetActiveGimmick(battlerAtk) == GIMMICK_DYNAMAX && gMovesInfo[move].category == DAMAGE_CATEGORY_STATUS)
         moveEffect = EFFECT_PROTECT;
@@ -3487,11 +3523,6 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
             ADJUST_SCORE(DECENT_EFFECT);
         break;
     case EFFECT_STRENGTH_SAP:
-        u32 atkStat = gBattleMons[battlerDef].attack;
-        u32 atkStage = gBattleMons[battlerDef].statStages[STAT_ATK];
-        atkStat *= gStatStageRatios[atkStage][0];
-        atkStat /= gStatStageRatios[atkStage][1];
-        u32 healPercent = atkStat * 100 / gBattleMons[battlerAtk].maxHP;
         if (ShouldRecover(battlerAtk, battlerDef, move, healPercent))
         {
             ADJUST_SCORE(GOOD_EFFECT);
@@ -4332,6 +4363,10 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
                || !CanTargetFaintAiWithMod(battlerDef, battlerAtk, toHeal, 0)))
                 ADJUST_SCORE(WEAK_EFFECT);    // Recycle healing berry if we can't otherwise faint the target and the target wont kill us after we activate the berry
         }
+        break;
+    case EFFECT_OCTOLOCK:
+        if (ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], STAT_SPDEF) || ShouldLowerStat(battlerDef, aiData->abilities[battlerDef], STAT_DEF) )
+            ADJUST_SCORE(DECENT_EFFECT);
         break;
     case EFFECT_RAGING_BULL:
     case EFFECT_BRICK_BREAK:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -894,7 +894,16 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
 
     if (TestIfSheerForceAffected(battlerAtk, move))
         return FALSE;
-    
+
+
+    switch (move)
+    {
+        case MOVE_SURF:
+        case MOVE_DIVE:
+            if (gBattleMons[battlerAtk].species == SPECIES_CRAMORANT)
+                return TRUE;
+    }        
+   
     switch (gMovesInfo[move].effect)
     {
     case EFFECT_FELL_STINGER:
@@ -994,27 +1003,27 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
             {
                 case MOVE_EFFECT_POISON:
                 case MOVE_EFFECT_TOXIC:
-                    if (AI_CanPoison(battlerAtk, battlerDef, abilityDef, move, MOVE_NONE))
+                    if (AI_CanPoison(battlerAtk, battlerDef, abilityDef, move, MOVE_NONE) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
                 case MOVE_EFFECT_BURN:
-                    if (AI_CanBurn(battlerAtk, battlerDef, abilityDef, BATTLE_PARTNER(battlerAtk), move, MOVE_NONE))
+                    if (AI_CanBurn(battlerAtk, battlerDef, abilityDef, BATTLE_PARTNER(battlerAtk), move, MOVE_NONE) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
                 case MOVE_EFFECT_FREEZE_OR_FROSTBITE:
-                    if (AI_CanGetFrostbite(battlerDef, abilityDef))
+                    if (AI_CanGetFrostbite(battlerDef, abilityDef) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
                 case MOVE_EFFECT_PARALYSIS:
-                    if (AI_CanParalyze(battlerAtk, battlerDef, abilityDef, move, MOVE_NONE))
+                    if (AI_CanParalyze(battlerAtk, battlerDef, abilityDef, move, MOVE_NONE) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
                 case MOVE_EFFECT_CONFUSION:
-                    if (AI_CanConfuse(battlerAtk, battlerDef, abilityDef, BATTLE_PARTNER(battlerAtk), move, MOVE_NONE))
+                    if (AI_CanConfuse(battlerAtk, battlerDef, abilityDef, BATTLE_PARTNER(battlerAtk), move, MOVE_NONE) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
                 case MOVE_EFFECT_FLINCH:
-                    if (ShouldTryToFlinch(battlerAtk, battlerDef, abilityAtk, abilityDef, move))
+                    if (ShouldTryToFlinch(battlerAtk, battlerDef, abilityAtk, abilityDef, move) && noOfHitsToKo > 1)
                         return TRUE;
                     break;
                 case MOVE_EFFECT_ATK_MINUS_1:
@@ -4682,13 +4691,15 @@ bool32 AI_ShouldCopyStatChanges(u32 battlerAtk, u32 battlerDef)
 bool32 AI_ShouldSetUpHazards(u32 battlerAtk, u32 battlerDef, struct AiLogicData *aiData)
 {
     if (aiData->abilities[battlerDef] == ABILITY_MAGIC_BOUNCE
-     || CountUsablePartyMons(battlerDef) == 0
-     || HasMoveEffect(battlerDef, EFFECT_TIDY_UP)
-     || HasMoveEffect(battlerDef, EFFECT_MAGIC_COAT)
-     || HasMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_RAPID_SPIN)
-     || HasMoveEffect(battlerDef, EFFECT_DEFOG))
+        || CountUsablePartyMons(battlerDef) < 2
+        || HasMoveEffect(battlerDef, EFFECT_MAGIC_COAT))
         return FALSE;
 
+    if (RandomPercentage(RNG_AI_NO_SETUP_HAZARDS, CONSIDER_NO_SETUP_HAZARDS_CHANCE) 
+        && (HasMoveEffect(battlerDef, EFFECT_TIDY_UP)
+        || HasMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_RAPID_SPIN)
+        || HasMoveEffect(battlerDef, EFFECT_DEFOG)))
+        return FALSE;
     return TRUE;
 }
 
@@ -4752,41 +4763,30 @@ bool32 AI_ShouldSpicyExtract(u32 battlerAtk, u32 battlerAtkPartner, u32 move, st
 u32 IncreaseSubstituteMoveScore(u32 battlerAtk, u32 battlerDef, u32 move)
 {
     u32 scoreIncrease = 0;
-    if (gMovesInfo[move].effect == EFFECT_SUBSTITUTE) // Substitute specific
-    {
-        if (HasAnyKnownMove(battlerDef) && GetBestDmgFromBattler(battlerDef, battlerAtk, AI_DEFENDING_NORMAL) < gBattleMons[battlerAtk].maxHP / 4)
-            scoreIncrease += GOOD_EFFECT;
-    }
-    else if (gMovesInfo[move].effect == EFFECT_SHED_TAIL) // Shed Tail specific
+
+    if (gBattleMons[battlerDef].status1 & STATUS1_SLEEP)
+        scoreIncrease += DECENT_EFFECT;
+
+    if (gMovesInfo[move].effect == EFFECT_SHED_TAIL) // Shed Tail specific
     {
         if ((ShouldPivot(battlerAtk, battlerDef, AI_DATA->abilities[battlerDef], move, AI_THINKING_STRUCT->movesetIndex))
         && (HasAnyKnownMove(battlerDef) && (GetBestDmgFromBattler(battlerDef, battlerAtk, AI_DEFENDING_NORMAL) < gBattleMons[battlerAtk].maxHP / 2)))
             scoreIncrease += BEST_EFFECT;
+
+        if (AI_DATA->hpPercents[battlerAtk] >= 75)
+            scoreIncrease += WEAK_EFFECT;        
     }
+    else if (gMovesInfo[move].effect == EFFECT_SUBSTITUTE) // Substitute specific
+    {
+        if (HasAnyKnownMove(battlerDef) && GetBestDmgFromBattler(battlerDef, battlerAtk, AI_DEFENDING_NORMAL) < gBattleMons[battlerAtk].maxHP / 4)
+            scoreIncrease += DECENT_EFFECT;
+    
+        if (AI_DATA->hpPercents[battlerAtk] >= 50)
+            scoreIncrease += WEAK_EFFECT;
 
-    if (gStatuses3[battlerDef] & STATUS3_PERISH_SONG)
-        scoreIncrease += GOOD_EFFECT;
-
-    if (gBattleMons[battlerDef].status1 & STATUS1_SLEEP)
-        scoreIncrease += GOOD_EFFECT;
-    else if (gBattleMons[battlerDef].status1 & (STATUS1_BURN | STATUS1_PSN_ANY | STATUS1_FROSTBITE))
-        scoreIncrease += DECENT_EFFECT;
-
-    // TODO:
-    // if (IsPredictedToSwitch(battlerDef, battlerAtk)
-    //     ADJUST_SCORE_PTR(DECENT_EFFECT);
-
-    if (HasMoveEffect(battlerDef, EFFECT_SLEEP)
-     || HasMoveEffect(battlerDef, EFFECT_TOXIC)
-     || HasMoveEffect(battlerDef, EFFECT_POISON)
-     || HasMoveEffect(battlerDef, EFFECT_PARALYZE)
-     || HasMoveEffect(battlerDef, EFFECT_WILL_O_WISP)
-     || HasMoveEffect(battlerDef, EFFECT_CONFUSE)
-     || HasMoveEffect(battlerDef, EFFECT_LEECH_SEED))
-        scoreIncrease += GOOD_EFFECT;
-
-    if (AI_DATA->hpPercents[battlerAtk] > 70)
-        scoreIncrease += WEAK_EFFECT;
+        if (scoreIncrease > BEST_EFFECT)
+            scoreIncrease = BEST_EFFECT;
+    }
     return scoreIncrease;
 }
 

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -63,8 +63,8 @@ static const u8 sStormThrowDescription[] = _(
     "in a critical hit.");
 
 static const u8 sCircleThrowDescription[] = _(
-    "Knocks the foe away to end\n"
-    "the battle.");
+    "Hits the foe and forces it\n"
+    "to switch out.");
 
 static const u8 sChipAwayDescription[] = _(
     "Strikes through the foe's\n"
@@ -103,8 +103,8 @@ static const u8 sHyperspaceHoleDescription[] = _(
     "Can't be evaded.");
 
 static const u8 sSuckerPunchDescription[] = _(
-    "Strikes first if the foe\n"
-    "is preparing an attack.");
+    "Strikes first, fails if \n"
+    "the foe is not attacking.");
 
 static const u8 sFeintDescription[] = _(
     "An attack that hits foes\n"
@@ -403,7 +403,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Guillotine"),
         .description = COMPOUND_STRING(
             "A powerful pincer attack\n"
-            "that may cause fainting."),
+            "causing faiting if it hits."),
         .effect = EFFECT_OHKO,
         .power = 1,
         .type = TYPE_NORMAL,
@@ -424,8 +424,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Razor Wind"),
         .description = COMPOUND_STRING(
-            "A 2-turn move that strikes\n"
-            "the foe on the 2nd turn."),
+            "Charges on 1st turn, strikes\n"
+            "on 2nd turn. High-crit ratio."),
         .effect = EFFECT_TWO_TURNS_ATTACK,
         .power = 80,
         .type = TYPE_NORMAL,
@@ -988,7 +988,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Take Down"),
         .description = COMPOUND_STRING(
             "A reckless charge attack\n"
-            "that also hurts the user."),
+            "with 25% recoil."),
         .effect = EFFECT_HIT,
         .power = 90,
         .type = TYPE_NORMAL,
@@ -1037,8 +1037,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Double-Edge"),
         .description = COMPOUND_STRING(
-            "A life-risking tackle that\n"
-            "also hurts the user."),
+            "A life-risking tackle with\n"
+            "33% recoil."),
         .effect = EFFECT_HIT,
         .power = 120,
         .type = TYPE_NORMAL,
@@ -1435,7 +1435,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Mist"),
         .description = COMPOUND_STRING(
             "Creates a mist that stops\n"
-            "reduction of abilities."),
+            "stat reduction."),
         .effect = EFFECT_MIST,
         .power = 0,
         .type = TYPE_ICE,
@@ -1728,8 +1728,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Submission"),
         .description = COMPOUND_STRING(
-            "A reckless body slam that\n"
-            "also hurts the user."),
+            "A reckless body slam with\n"
+            "25% recoil."),
         .effect = EFFECT_HIT,
         .power = 80,
         .type = TYPE_FIGHTING,
@@ -1894,7 +1894,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Leech Seed"),
         .description = COMPOUND_STRING(
             "Plants a seed on the foe to\n"
-            "steal HP on every turn."),
+            "steal 1/8 HP on every turn."),
         .effect = EFFECT_LEECH_SEED,
         .power = 0,
         .type = TYPE_GRASS,
@@ -2548,8 +2548,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Teleport"),
         .description = COMPOUND_STRING(
-            "A psychic move for fleeing\n"
-            "from battle instantly."),
+            "A psychic move that lets you\n"
+            "flee at the end of the turn."),
         .effect = EFFECT_TELEPORT,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -2628,7 +2628,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_DEFENSE_DOWN_2,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 85,
+        .accuracy = 100,
         .pp = 40,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2945,8 +2945,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Focus Energy"),
         .description = COMPOUND_STRING(
-            "Focuses power to raise the\n"
-            "critical-hit ratio."),
+            "Focuses power to sharply raise\n"
+            "the critical-hit ratio."),
         .effect = EFFECT_FOCUS_ENERGY,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -3301,7 +3301,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Skull Bash"),
         .description = COMPOUND_STRING(
-            "Tucks in the head, then\n"
+            "Boosts defense on 1st turn, then\n"
             "attacks on the next turn."),
         .effect = EFFECT_TWO_TURNS_ATTACK,
         .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 130 : 100,
@@ -3404,8 +3404,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Kinesis"),
         .description = COMPOUND_STRING(
-            "Distracts the foe.\n"
-            "May lower accuracy."),
+            "Distracts the foe\n"
+            "to lower accuracy"),
         .effect = EFFECT_ACCURACY_DOWN,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -3454,7 +3454,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("High Jump Kick"),
         .description = COMPOUND_STRING(
             "A jumping knee kick. If it\n"
-            "misses, the user is hurt."),
+            "misses, the user loses 50% max hp."),
         #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 130,
         #elif B_UPDATED_MOVE_DATA == GEN_4
@@ -3529,7 +3529,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Poison Gas"),
         .description = COMPOUND_STRING(
             "Envelops the foe in a\n"
-            "gas that may poison."),
+            "gas that causes poison."),
         .accuracy = 90,
         .effect = EFFECT_POISON,
         .power = 0,
@@ -3735,7 +3735,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Spore"),
         .description = COMPOUND_STRING(
             "Scatters a cloud of spores\n"
-            "that always induce sleep."),
+            "that always induces sleep."),
         .effect = EFFECT_SLEEP,
         .power = 0,
         .type = TYPE_GRASS,
@@ -4266,8 +4266,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Thief"),
         .description = COMPOUND_STRING(
-            "While attacking, it may\n"
-            "steal the foe's held item."),
+            "While attacking, steals\n"
+            "the foe's held item."),
         .effect = EFFECT_HIT,
         .power = 60,
         .type = TYPE_DARK,
@@ -4561,7 +4561,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Spite"),
         .description = COMPOUND_STRING(
-            "Spitefully cuts the PP\n"
+            "Spitefully cuts 4 PP\n"
             "of the foe's last move."),
         .effect = EFFECT_SPITE,
         .power = 0,
@@ -4708,7 +4708,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Sweet Kiss"),
         .description = COMPOUND_STRING(
             "Demands a kiss with a cute\n"
-            "look. May cause confusion."),
+            "look that causes confusion."),
         .effect = EFFECT_CONFUSE,
         .power = 0,
         .type = B_UPDATED_MOVE_TYPES >= GEN_6 ? TYPE_FAIRY : TYPE_NORMAL,
@@ -4731,7 +4731,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Belly Drum"),
         .description = COMPOUND_STRING(
             "Maximizes Attack while\n"
-            "sacrificing HP."),
+            "sacrificing 50% max HP."),
         .effect = EFFECT_BELLY_DRUM,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -4781,8 +4781,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Mud-Slap"),
         .description = COMPOUND_STRING(
-            "Hurls mud in the foe's face\n"
-            "to reduce its accuracy."),
+            "Hurls mud in the foe's \n"
+            "face."),
         .effect = EFFECT_HIT,
         .power = 40,
         .type = TYPE_GROUND,
@@ -4803,7 +4803,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Octazooka"),
         .description = COMPOUND_STRING(
             "Fires a lump of ink to\n"
-            "damage and cut accuracy."),
+            "damage the foe."),
         .effect = EFFECT_HIT,
         .power = 65,
         .type = TYPE_WATER,
@@ -4901,7 +4901,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Destiny Bond"),
         .description = COMPOUND_STRING(
-            "If the user faints, the foe\n"
+            "If the user is killed, the foe\n"
             "is also made to faint."),
         .effect = EFFECT_DESTINY_BOND,
         .power = 0,
@@ -5080,7 +5080,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Sandstorm"),
         .description = COMPOUND_STRING(
             "Causes a sandstorm that\n"
-            "rages for several turns."),
+            "rages for 5 turns."),
         .effect = EFFECT_SANDSTORM,
         .power = 0,
         .type = TYPE_ROCK,
@@ -5716,7 +5716,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Encore"),
         .description = COMPOUND_STRING(
             "Makes the foe repeat its\n"
-            "last move over 2 to 6 turns."),
+            "last move over 3 turns."),
         .effect = EFFECT_ENCORE,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -5740,8 +5740,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Pursuit"),
         .description = COMPOUND_STRING(
-            "Inflicts bad damage if used\n"
-            "on a foe switching out."),
+            "Inflicts double damage if\n"
+            "the foe is switching out."),
         .effect = EFFECT_PURSUIT,
         .power = 40,
         .type = TYPE_DARK,
@@ -5763,8 +5763,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Rapid Spin"),
         .description = COMPOUND_STRING(
-            "Spins the body at high\n"
-            "speed to strike the foe."),
+            "Removes hazards and\n"
+            "raises speed."),
         .effect = EFFECT_HIT,
         .power = 50,
         .type = TYPE_NORMAL,
@@ -5973,8 +5973,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Hidden Power"),
         .description = COMPOUND_STRING(
-            "The effectiveness varies\n"
-            "with the user."),
+            "The type changes\n"
+            "with the user's IVs."),
         .power = B_HIDDEN_POWER_DMG >= GEN_6 ? 60 : 1,
         .effect = EFFECT_HIDDEN_POWER,
         .type = TYPE_NORMAL,
@@ -8036,7 +8036,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_SPECIAL_DEFENSE_DOWN_2,
         .power = 0,
         .type = TYPE_STEEL,
-        .accuracy = 85,
+        .accuracy = 100,
         .pp = 40,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -8293,8 +8293,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Muddy Water"),
         .description = COMPOUND_STRING(
-            "Attacks with muddy water.\n"
-            "May lower accuracy."),
+            "Attacks with muddy \n"
+            "water."),
         .effect = EFFECT_HIT,
         .power = 95,
         .type = TYPE_WATER,
@@ -10658,8 +10658,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Mud Bomb"),
         .description = COMPOUND_STRING(
-            "Throws a blob of mud to\n"
-            "damage and cut accuracy."),
+            "Throws a blob of mud\n"
+            "to damage."),
         .effect = EFFECT_HIT,
         .power = 65,
         .type = TYPE_GROUND,

--- a/src/data/text/item_descriptions.h
+++ b/src/data/text/item_descriptions.h
@@ -3199,7 +3199,7 @@ static const u8 sTM33Desc[] = _(
 static const u8 sTM34Desc[] = _(
     "A psychic move for\n"
     "fleeing from battle\n"
-    "instantly.");
+    "at the end of the turn.");
 
 static const u8 sTM35Desc[] = _(
     "Looses a stream of\n"
@@ -3214,7 +3214,7 @@ static const u8 sTM36Desc[] = _(
 static const u8 sTM37Desc[] = _(
     "Causes a sandstorm\n"
     "that hits the foe\n"
-    "over several turns.");
+    "for 5 turns.");
 
 static const u8 sTM38Desc[] = _(
     "A powerful fire\n"
@@ -3258,7 +3258,7 @@ static const u8 sTM45Desc[] = _(
 
 static const u8 sTM46Desc[] = _(
     "While attacking,\n"
-    "it may steal the\n"
+    "steal the\n"
     "foe's held item.");
 
 static const u8 sTM47Desc[] = _(

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -419,3 +419,35 @@ AI_SINGLE_BATTLE_TEST("sheer force moveeffectinplus")
         }
     }
 }
+
+
+AI_SINGLE_BATTLE_TEST("status chance are not positive effect on kills")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_VOLCANION){ Level(85); HP(1); Nature(NATURE_TIMID); Ability(ABILITY_WATER_ABSORB); Speed(165); Moves(MOVE_FLAMETHROWER); }
+        OPPONENT(SPECIES_GRIMMSNARL){ Level(85); Nature(NATURE_QUIET); Ability(ABILITY_PRANKSTER); Speed(96); Moves(MOVE_THUNDERBOLT, MOVE_MOONBLAST, MOVE_POWER_UP_PUNCH); }
+    } WHEN {
+        TURN { 
+            MOVE(player, MOVE_FLAMETHROWER);
+            SCORE_EQ_VAL(opponent, MOVE_THUNDERBOLT, 104);
+            SCORE_EQ_VAL(opponent, MOVE_MOONBLAST, 104);
+            SCORE_EQ_VAL(opponent, MOVE_POWER_UP_PUNCH, 105);
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("surf is positive effect for cramorant")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_BLAZIKEN){ Level(44); Nature(NATURE_ADAMANT); Ability(ABILITY_STRIKER); Speed(89); HP(20); Moves(MOVE_DETECT, MOVE_TRIPLE_ARROWS); }
+        OPPONENT(SPECIES_CRAMORANT){ Level(85); Nature(NATURE_QUIET); Ability(ABILITY_GULP_MISSILE); Speed(96); Moves(MOVE_SURF, MOVE_SCALD); }
+    } WHEN {
+        TURN { 
+            MOVE(player, MOVE_TRIPLE_ARROWS);
+            SCORE_EQ_VAL(opponent, MOVE_SURF, 107);
+            SCORE_EQ_VAL(opponent, MOVE_SCALD, 106);
+        }
+    }
+}


### PR DESCRIPTION

## Description
Move changes:
- Fixed move descriptions that were inaccurate in summary and TMs. 
- Buffed Metal sound and Screech accuracy from 85 to 100. 
Move scoring changes:
- Added handling for Octolock.
- Changed Shell Smash AI so AI won't click it twice and will see damage more accurately. 
- Changed subtitute AI to make it less abusable. 
- Explosion can no longer be clicked if last mon in party, similar to Final Gambit. 
- Surf and Dive are now positive effects if used by Cramorant. 
- All moves that hinder target are no longer positive effects when AI sees a kill. 
- Hazards can't be clicked if player has less than 2 mons total. 
- Hazards have 20% chance to be clicked if player has defog, rapid spin or tidy up. 
Added tests. 



## **People who collaborated with me in this PR**
Shoutout whybo



## **Discord contact info**
MaximeGr
