### PR TITLE
fix (EFFECT_BOLT_BEAK): AI ignores last used move on first turn on field to score fishious rend/bolt beak correctly

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9032,7 +9032,8 @@ static inline u32 CalcMoveBasePower(struct DamageCalculationData *damageCalcData
     case EFFECT_BOLT_BEAK:
         if (AI_DATA->aiCalcInProgress)
         {
-            if (AI_IsFaster(battlerAtk, battlerDef, move, AI_DATA->lastUsedMove[battlerDef], CONSIDER_PRIORITY))
+            u32 lastKnownMove = gDisableStructs[battlerAtk].isFirstTurn ? MOVE_NONE : AI_DATA->lastUsedMove[battlerDef];
+            if (AI_IsFaster(battlerAtk, battlerDef, move, lastKnownMove, CONSIDER_PRIORITY))
                 basePower *= 2;
         }
         else if (GetBattlerTurnOrderNum(battlerAtk) < GetBattlerTurnOrderNum(battlerDef)

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -451,3 +451,23 @@ AI_SINGLE_BATTLE_TEST("surf is positive effect for cramorant")
         }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("Bolt Beak/Fishious Rend - AI will ignore player's last used move on its first turn on the field")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_SAMUROTT){ Level(44); Moves(MOVE_VACUUM_WAVE, MOVE_CUT); }
+        OPPONENT(SPECIES_NINETALES_ALOLA){ Level(1); HP(1); Moves(MOVE_TACKLE); Ability(ABILITY_SNOW_WARNING); }
+        OPPONENT(SPECIES_ARCTOVISH){ Level(42); Moves(MOVE_CRUNCH, MOVE_FISHIOUS_REND); Ability(ABILITY_SLUSH_RUSH); }
+    } WHEN {
+        TURN {
+            MOVE(player, MOVE_VACUUM_WAVE);
+            EXPECT_MOVE(opponent, MOVE_TACKLE);
+            EXPECT_SEND_OUT(opponent, 1);
+        }
+        TURN {
+            MOVE(player, MOVE_CUT);
+            EXPECT_MOVE(opponent, MOVE_FISHIOUS_REND);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Previously, in the test case provided, 
- Samurott takes the KO with a prio move
- Arctovish comes in
- Arctovish does not see the damage boost on Fishious Rend despite outspeeding in the snow, because the last used player move was a priority move
- Arctovish would click Crunch on least hits to KO instead of what players would intuitively expect, which is Fishious Rend with speed comparison damage boost least hits to KO

This new change preserves the anti-prio abuse of the Bolt Beak/Fishious Rend calculations for all turns after turn 1 on the field, while addressing the edge case of prio KO --> EFFECT_BOLT_BEAK mon hits the field --> selects unexpected move based on the field state.

## **People who collaborated with me in this PR**
@MaximeGr00

## Things to note in the release changelog:
- Bolt Beak/Fishious Rend - when a Pokemon with these moves enters the battlefield, they will ignore your last used move on that turn when calculating damage for Bolt Beak/Fishious Rend, preventing unintuitive AI behavior if you took a KO with a priority move.

## **Discord contact info**
ghostyboyy97
