### PR TITLE
fix (dazzling): adjustments to AI awareness of Dazzling, Armor Tail, and Queenly Majesty

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -871,6 +871,7 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
     gBattleStruct->zmove.baseMoves[battlerAtk] = MOVE_NONE;
     if (toggledGimmick)
         SetActiveGimmick(battlerAtk, GIMMICK_NONE);
+
     AI_DATA->aiCalcInProgress = FALSE;
     return simDamage;
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4335,7 +4335,8 @@ static void HandleTurnActionSelectionState(void)
                     AI_DATA->shouldSwitch |= (1u << battler);
                 gBattleStruct->prevTurnSpecies[battler] = gBattleMons[battler].species;
 
-                // Do scoring
+                // Do scoring - force AI_DATA->aiCalcInProgress = TRUE for proper awareness when choosing move or action
+                AI_DATA->aiCalcInProgress = TRUE;
                 gBattleStruct->aiMoveOrAction[battler] = BattleAI_ChooseMoveOrAction();
                 ModifySwitchAfterMoveScoring(battler);
                 AI_DATA->aiCalcInProgress = FALSE;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4877,6 +4877,8 @@ u32 GetBattlerTotalSpeedStatArgs(u32 battler, u32 ability, u32 holdEffect)
             speed *= 2;
         else if (ability == ABILITY_CHLOROPHYLL && holdEffect != HOLD_EFFECT_UTILITY_UMBRELLA && gBattleWeather & B_WEATHER_SUN)
             speed *= 2;
+        else if (ability == ABILITY_FLOWER_GIFT && gBattleMons[battler].species == SPECIES_CHERRIM_SUNSHINE && holdEffect != HOLD_EFFECT_UTILITY_UMBRELLA && gBattleWeather & B_WEATHER_SUN)
+            speed *= 1.5;
         else if (ability == ABILITY_SAND_RUSH   && gBattleWeather & B_WEATHER_SANDSTORM)
             speed *= 2;
         else if (ability == ABILITY_SLUSH_RUSH  && (gBattleWeather & (B_WEATHER_HAIL | B_WEATHER_SNOW)))

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4048,7 +4048,7 @@ u32 CanAbilityBlockMove(u32 battlerAtk, u32 battlerDef, u32 move, u32 abilityDef
     case ABILITY_ARMOR_TAIL:
         if (GetBattlerSide(battlerAtk) != GetBattlerSide(battlerDef))
         {
-            u32 priority = AI_DATA->aiCalcInProgress ? GetMovePriority(battlerAtk, move) : GetChosenMovePriority(battlerAtk);
+            s8 priority = AI_DATA->aiCalcInProgress ? GetMovePriority(battlerAtk, move) : GetChosenMovePriority(battlerAtk);
             if (priority > 0)
                 effect = MOVE_BLOCKED_BY_DAZZLING;
         }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9742,18 +9742,6 @@ static inline u32 CalcAttackStat(struct DamageCalculationData *damageCalcData, u
         break;
     }
 
-    // ally's abilities
-    if (IsBattlerAlive(BATTLE_PARTNER(battlerAtk)))
-    {
-        switch (GetBattlerAbility(BATTLE_PARTNER(battlerAtk)))
-        {
-        case ABILITY_FLOWER_GIFT:
-            if (gBattleMons[BATTLE_PARTNER(battlerAtk)].species == SPECIES_CHERRIM_SUNSHINE && IsBattlerWeatherAffected(BATTLE_PARTNER(battlerAtk), B_WEATHER_SUN) && IS_MOVE_PHYSICAL(move))
-                modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(1.5));
-            break;
-        }
-    }
-
     // field abilities
     if (IsAbilityOnField(ABILITY_VESSEL_OF_RUIN) && atkAbility != ABILITY_VESSEL_OF_RUIN && IS_MOVE_SPECIAL(move))
         modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(0.75));
@@ -9894,26 +9882,10 @@ static inline u32 CalcDefenseStat(struct DamageCalculationData *damageCalcData, 
                 RecordAbilityBattle(battlerDef, ABILITY_GRASS_PELT);
         }
         break;
-    case ABILITY_FLOWER_GIFT:
-        if (gBattleMons[battlerDef].species == SPECIES_CHERRIM_SUNSHINE && IsBattlerWeatherAffected(battlerDef, B_WEATHER_SUN) && !usesDefStat)
-            modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(1.5));
-        break;
     case ABILITY_PURIFYING_SALT:
         if (moveType == TYPE_GHOST)
             modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(2.0));
         break;
-    }
-
-    // ally's abilities
-    if (IsBattlerAlive(BATTLE_PARTNER(battlerDef)))
-    {
-        switch (GetBattlerAbility(BATTLE_PARTNER(battlerDef)))
-        {
-        case ABILITY_FLOWER_GIFT:
-            if (gBattleMons[BATTLE_PARTNER(battlerDef)].species == SPECIES_CHERRIM_SUNSHINE && IsBattlerWeatherAffected(BATTLE_PARTNER(battlerDef), B_WEATHER_SUN) && !usesDefStat)
-                modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(1.5));
-            break;
-        }
     }
 
     // field abilities

--- a/test/battle/ability/dazzling.c
+++ b/test/battle/ability/dazzling.c
@@ -50,3 +50,69 @@ DOUBLE_BATTLE_TEST("Dazzling, Queenly Majesty and Armor Tail protect users partn
         MESSAGE("Wobbuffet cannot use Quick Attack!");
     }
 }
+
+AI_DOUBLE_BATTLE_TEST("Dazzling/Queenly Majesty/Armor Tail - switch-in calcs should no longer break on-field scoring due to aiCalcInProgress flip and Slither Wing stays in")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+
+        PLAYER(SPECIES_RHYPERIOR){ Level(100); Moves(MOVE_TACKLE); }
+        PLAYER(SPECIES_VESPIQUEN){ Level(100); Moves(MOVE_LUNGE); }
+
+        OPPONENT(SPECIES_SLITHER_WING){ Level(100); Moves(MOVE_FIRST_IMPRESSION, MOVE_FLARE_BLITZ); Nature(NATURE_BRAVE); Item(ITEM_LIFE_ORB); }
+        OPPONENT(SPECIES_SHIFTRY){ Level(100); Moves(MOVE_LEAF_STORM); }
+
+        OPPONENT(SPECIES_CINDERACE) { Level(100); Moves(MOVE_PYRO_BALL); }
+    } WHEN {
+        TURN { 
+            MOVE(playerLeft, MOVE_TACKLE, target:opponentLeft);
+            MOVE(playerRight, MOVE_LUNGE, target:opponentRight);
+            EXPECT_MOVE(opponentLeft, MOVE_FLARE_BLITZ, target:playerRight);
+            EXPECT_MOVE(opponentRight, MOVE_LEAF_STORM, target:playerLeft);
+        }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("Dazzling/Queenly Majesty/Armor Tail - move slot order shouldn't matter")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+
+        PLAYER(SPECIES_RHYPERIOR){ Level(100); Moves(MOVE_TACKLE); }
+        PLAYER(SPECIES_VESPIQUEN){ Level(100); Moves(MOVE_LUNGE); }
+
+        OPPONENT(SPECIES_SLITHER_WING){ Level(100); Moves(MOVE_FLARE_BLITZ, MOVE_FIRST_IMPRESSION); Nature(NATURE_BRAVE); Item(ITEM_LIFE_ORB); }
+        OPPONENT(SPECIES_SHIFTRY){ Level(100); Moves(MOVE_LEAF_STORM); }
+
+        OPPONENT(SPECIES_CINDERACE) { Level(100); Moves(MOVE_PYRO_BALL); }
+    } WHEN {
+        TURN { 
+            MOVE(playerLeft, MOVE_TACKLE, target:opponentLeft);
+            MOVE(playerRight, MOVE_LUNGE, target:opponentRight);
+            EXPECT_MOVE(opponentLeft, MOVE_FLARE_BLITZ, target:playerRight);
+            EXPECT_MOVE(opponentRight, MOVE_LEAF_STORM, target:playerLeft);
+        }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("Dazzling/Queenly Majesty/Armor Tail - with only first impression, Slither Wing should instead switch out")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+
+        PLAYER(SPECIES_RHYPERIOR){ Level(100); Moves(MOVE_TACKLE); }
+        PLAYER(SPECIES_VESPIQUEN){ Level(100); Moves(MOVE_LUNGE); }
+
+        OPPONENT(SPECIES_SLITHER_WING){ Level(100); Moves(MOVE_FIRST_IMPRESSION); Nature(NATURE_BRAVE); Item(ITEM_LIFE_ORB); }
+        OPPONENT(SPECIES_SHIFTRY){ Level(100); Moves(MOVE_LEAF_STORM); }
+
+        OPPONENT(SPECIES_CINDERACE) { Level(100); Moves(MOVE_PYRO_BALL); }
+    } WHEN {
+        TURN { 
+            MOVE(playerLeft, MOVE_TACKLE, target:opponentLeft);
+            MOVE(playerRight, MOVE_LUNGE, target:opponentRight);
+            EXPECT_SWITCH(opponentLeft, 2);
+            EXPECT_MOVE(opponentRight, MOVE_LEAF_STORM, target:playerLeft);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes two bugs.
1. These priority-blocking abilities no longer block negative priority moves (priority checking functions were returning a signed integer, but were stored as an unsigned integer in CanAbilityBlockMove).
2. These priority-blocking abilities were causing incorrect scoring when evaluating AI flags if the first move slot of the AI Pokemon was a priority move and there were any other Pokemon alive in the party.

An additional small change was added fixing Flower Gift to buff self Attack and Speed by 50%, instead of self + ally Attack and Special Defense by 50%.

## Issue(s) that this PR fixes
Fixes #139 , fixes #140 

## **People who collaborated with me in this PR**
@MaximeGr00

## Things to note in the release changelog:
- Negative priority moves will no longer be blocked by Dazzling, Queenly Majesty, and Armor Tail.
- Fixes were made to AI scoring against Dazzling, Queenly Majesty, and Armor Tail to prevent unintended switch cases from occurring.
- Flower gift now correctly boost's Cherrim's Attack and Speed by 50% in the sun, instead of it and it's ally's Attack and Special Defense by 50%.

## **Discord contact info**
ghostyboyy97
