### PR TITLE
Fix for movesetIndex, added GetMoveIndex function

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -104,6 +104,7 @@ bool32 IsBattlerTrapped(u32 battlerAtk, u32 battlerDef);
 s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler2, u32 aiMoveConsidered, u32 playerMoveConsidered, enum ConsiderPriority considerPriority);
 bool32 CanTargetFaintAi(u32 battlerDef, u32 battlerAtk);
 u32 NoOfHitsForTargetToFaintBattler(u32 battlerDef, u32 battlerAtk, enum AiConsiderEndure considerEndure);
+u32 GetMoveIndex(u32 battler, u32 move);
 u32 GetBestDmgMoveFromBattler(u32 battlerAtk, u32 battlerDef, enum DamageCalcContext calcContext);
 u32 GetBestDmgFromBattler(u32 battler, u32 battlerTarget, enum DamageCalcContext calcContext);
 bool32 CanTargetMoveFaintAi(u32 move, u32 battlerDef, u32 battlerAtk, u32 nHits);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1148,7 +1148,7 @@ static bool32 AI_IsMoveEffectInMinus(u32 battlerAtk, u32 battlerDef, u32 move, s
 // Checks if one of the moves has side effects or perks, assuming equal dmg or equal no of hits to KO
 enum MoveComparisonResult AI_WhichMoveBetter(u32 move1, u32 move2, u32 battlerAtk, u32 battlerDef, s32 noOfHitsToKo)
 {
-    bool32 effect1, effect2;
+    bool32 effect1minus, effect1plus, effect2minus, effect2plus;
     u32 defAbility = AI_DATA->abilities[battlerDef];
     u32 atkAbility = AI_DATA->abilities[battlerAtk];
 
@@ -1160,22 +1160,28 @@ enum MoveComparisonResult AI_WhichMoveBetter(u32 move1, u32 move2, u32 battlerAt
         if (gMovesInfo[move1].makesContact && !gMovesInfo[move2].makesContact)
             return MOVE_LOST_COMPARISON;
         if (gMovesInfo[move2].makesContact && !gMovesInfo[move1].makesContact)
-            return MOVE_WON_COMPARISON;;
+            return MOVE_WON_COMPARISON;
     }
 
     // Check additional effects.
-    effect1 = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move1, noOfHitsToKo);
-    effect2 = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move2, noOfHitsToKo);
-    if (effect2 && !effect1)
+    AI_THINKING_STRUCT->movesetIndex = GetMoveIndex(battlerAtk, move1);
+    effect1minus = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move1, noOfHitsToKo);
+    effect1plus = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move1, noOfHitsToKo);
+
+    AI_THINKING_STRUCT->movesetIndex = GetMoveIndex(battlerAtk, move2);
+    effect2plus = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move2, noOfHitsToKo);
+    effect2minus = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move2, noOfHitsToKo);
+
+    AI_THINKING_STRUCT->movesetIndex = 0;
+
+    if (effect2minus && !effect1minus)
         return MOVE_WON_COMPARISON;;
-    if (effect1 && !effect2)
+    if (effect1minus && !effect2minus)
         return MOVE_LOST_COMPARISON;
 
-    effect1 = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move1, noOfHitsToKo);
-    effect2 = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move2, noOfHitsToKo);
-    if (effect2 && !effect1)
+    if (effect2plus && !effect1plus)
         return MOVE_LOST_COMPARISON;
-    if (effect1 && !effect2)
+    if (effect1plus && !effect2plus)
         return MOVE_WON_COMPARISON;;
 
     return MOVE_NEUTRAL_COMPARISON;
@@ -1471,6 +1477,19 @@ void GetBestDmgMovesFromBattler(u32 battlerAtk, u32 battlerDef, enum DamageCalcC
             }
         }
     }
+}
+
+u32 GetMoveIndex(u32 battler, u32 move)
+{
+    u16 *moves = GetMovesArray(battler);
+
+    for (u32 moveIndex = 0; moveIndex < MAX_MON_MOVES; moveIndex++)
+    {
+        if (moves[moveIndex] == move)
+            return moveIndex;
+    }
+
+    return MAX_MON_MOVES;
 }
 
 u32 GetBestDmgMoveFromBattler(u32 battlerAtk, u32 battlerDef, enum DamageCalcContext calcContext)

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -2131,6 +2131,7 @@ void CB2_OpenPokedexPlusHGSS(void)
 
 void CB2_OpenPokedexPlusHGSSToMon()
 {
+    u16 species = gSpeciesToLoad;
     if (!POKEDEX_PLUS_HGSS) return; // prevents the compiler from emitting static .rodata
                                     // if the feature is disabled
     switch (gMain.state)
@@ -2155,7 +2156,6 @@ void CB2_OpenPokedexPlusHGSSToMon()
         gMain.state++;
         break;
     case 2:
-        u16 species = gSpeciesToLoad;
         sPokedexView = AllocZeroed(sizeof(struct PokedexView));
         ResetPokedexView(sPokedexView);
         u16 dexNum = SpeciesToNationalPokedexNum(species);

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -546,3 +546,25 @@ AI_SINGLE_BATTLE_TEST("Bolt Beak/Fishious Rend - AI will ignore player's last us
         }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI's comparison of damaging moves correctly reads moveset indexes for effects")
+{
+    u32 move = MOVE_NONE;
+    PARAMETRIZE { move = MOVE_TACKLE; }
+    PARAMETRIZE { move = MOVE_DUAL_CHOP; }
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_RAPIDASH_GALAR){ Level(100); Nature(NATURE_JOLLY); Moves(MOVE_TACKLE);}
+        OPPONENT(SPECIES_HAXORUS){ Level(64); Nature(NATURE_JOLLY); Ability(ABILITY_MOLD_BREAKER); Moves(move, MOVE_DRILL_RUN, MOVE_POISON_JAB); }
+    } WHEN {
+        TURN { 
+            MOVE(player, MOVE_TACKLE);
+            if (move == MOVE_WATERFALL)
+                SCORE_EQ_VAL(opponent, MOVE_WATERFALL, 100);
+            else if (move == MOVE_DUAL_CHOP)
+                SCORE_EQ_VAL(opponent, MOVE_DUAL_CHOP, 60);
+            SCORE_EQ_VAL(opponent, MOVE_DRILL_RUN, 100);
+            SCORE_EQ_VAL(opponent, MOVE_POISON_JAB, 101);
+        }
+    }
+}


### PR DESCRIPTION
## Description
A bug was identified where AI would see its move as being of effectiveness 0 when evaluating if it can poison/paralyze etc for move comparison if the move in the first slot was a move the player is immune to. 
This fixes the way AI retrieves move index. 

## **People who collaborated with me in this PR**
@pawkkie did all the work shoutout 

## **Discord contact info**
MaximeGr
