### PR TITLE
fix (parental bond): AI no longer sees parental bond second hit on spread moves in double battles

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9342,7 +9342,7 @@ static inline u32 CalcMoveBasePowerAfterModifiers(struct DamageCalculationData *
         modifier = uq4_12_multiply(modifier, GetSupremeOverlordModifier(battlerAtk));
         break;
     case ABILITY_PARENTAL_BOND:
-        if(fromAiCode)
+        if (fromAiCode && IsMoveAffectedByParentalBond(move, battlerAtk))
             modifier = uq4_12_multiply(modifier, UQ_4_12(1.25));
         break;
     case ABILITY_ORAORAORAORA:

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -589,25 +589,3 @@ AI_SINGLE_BATTLE_TEST("Retaliate sees damage correctly on the field")
         }
     }
 }
-
-AI_DOUBLE_BATTLE_TEST("Doubles switch calc bug")
-{
-    GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_SCYTHER){ Level(76); Moves(MOVE_BUG_BITE); Ability(ABILITY_TECHNICIAN); Nature(NATURE_ADAMANT); Item(ITEM_CHOICE_SCARF); Speed(295); }
-        PLAYER(SPECIES_ROTOM_FAN){ Level(76); Moves(MOVE_VOLT_SWITCH); Ability(ABILITY_MOTOR_DRIVE); Speed(159); HP(135); }
-        PLAYER(SPECIES_GRIMMSNARL){ Level(76); Moves(MOVE_FAKE_OUT); Nature(NATURE_IMPISH); Ability(ABILITY_INFILTRATOR); Speed(116); HP(77); }
-        OPPONENT(SPECIES_TAPU_LELE){ Level(76); Nature(NATURE_TIMID); Moves(MOVE_PSYCHIC, MOVE_THUNDERBOLT); Ability(ABILITY_PSYCHIC_SURGE); Speed(189); }
-        OPPONENT(SPECIES_IRON_LEAVES){ Level(76); Nature(NATURE_JOLLY); Moves(MOVE_PSYBLADE); Speed(206); }
-        OPPONENT(SPECIES_FARIGIRAF){ Level(76); Nature(NATURE_MODEST); Moves(MOVE_DAZZLING_GLEAM); Ability(ABILITY_PARENTAL_BOND); Speed(119); }
-        OPPONENT(SPECIES_ALAKAZAM){ Level(76); Nature(NATURE_TIMID); Moves(MOVE_FOCUS_BLAST); Speed(231); }
-    } WHEN {
-        TURN {
-            MOVE(playerLeft, MOVE_BUG_BITE, target:opponentRight);
-            SWITCH(playerRight, 2);
-            EXPECT_MOVE(opponentLeft, MOVE_PSYCHIC, target:playerRight);
-            EXPECT_MOVE(opponentRight, MOVE_PSYBLADE, target:playerLeft);
-            EXPECT_SEND_OUT(opponentRight, 3);
-        }
-    }
-}

--- a/test/battle/ai/ai_calc_best_move_score.c
+++ b/test/battle/ai/ai_calc_best_move_score.c
@@ -589,3 +589,25 @@ AI_SINGLE_BATTLE_TEST("Retaliate sees damage correctly on the field")
         }
     }
 }
+
+AI_DOUBLE_BATTLE_TEST("Doubles switch calc bug")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_SCYTHER){ Level(76); Moves(MOVE_BUG_BITE); Ability(ABILITY_TECHNICIAN); Nature(NATURE_ADAMANT); Item(ITEM_CHOICE_SCARF); Speed(295); }
+        PLAYER(SPECIES_ROTOM_FAN){ Level(76); Moves(MOVE_VOLT_SWITCH); Ability(ABILITY_MOTOR_DRIVE); Speed(159); HP(135); }
+        PLAYER(SPECIES_GRIMMSNARL){ Level(76); Moves(MOVE_FAKE_OUT); Nature(NATURE_IMPISH); Ability(ABILITY_INFILTRATOR); Speed(116); HP(77); }
+        OPPONENT(SPECIES_TAPU_LELE){ Level(76); Nature(NATURE_TIMID); Moves(MOVE_PSYCHIC, MOVE_THUNDERBOLT); Ability(ABILITY_PSYCHIC_SURGE); Speed(189); }
+        OPPONENT(SPECIES_IRON_LEAVES){ Level(76); Nature(NATURE_JOLLY); Moves(MOVE_PSYBLADE); Speed(206); }
+        OPPONENT(SPECIES_FARIGIRAF){ Level(76); Nature(NATURE_MODEST); Moves(MOVE_DAZZLING_GLEAM); Ability(ABILITY_PARENTAL_BOND); Speed(119); }
+        OPPONENT(SPECIES_ALAKAZAM){ Level(76); Nature(NATURE_TIMID); Moves(MOVE_FOCUS_BLAST); Speed(231); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_BUG_BITE, target:opponentRight);
+            SWITCH(playerRight, 2);
+            EXPECT_MOVE(opponentLeft, MOVE_PSYCHIC, target:playerRight);
+            EXPECT_MOVE(opponentRight, MOVE_PSYBLADE, target:playerLeft);
+            EXPECT_SEND_OUT(opponentRight, 3);
+        }
+    }
+}

--- a/test/battle/ai/ai_switching.c
+++ b/test/battle/ai/ai_switching.c
@@ -1471,3 +1471,24 @@ AI_SINGLE_BATTLE_TEST("Retaliate sees damage correctly for post ko switch in")
     }
 }
 
+AI_DOUBLE_BATTLE_TEST("ABILITY_PARENTAL_BOND - AI should not calc parental bond extra hit in double battles (hits timeout, but .elf shows correct data)")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_SCYTHER){ Level(76); Moves(MOVE_BUG_BITE); Ability(ABILITY_TECHNICIAN); Nature(NATURE_ADAMANT); Item(ITEM_CHOICE_SCARF); Speed(295); }
+        PLAYER(SPECIES_ROTOM_FAN){ Level(76); Moves(MOVE_VOLT_SWITCH); Ability(ABILITY_MOTOR_DRIVE); Speed(159); HP(135); }
+        PLAYER(SPECIES_GRIMMSNARL){ Level(76); Moves(MOVE_FAKE_OUT); Nature(NATURE_IMPISH); Ability(ABILITY_INFILTRATOR); Speed(116); HP(77); }
+        OPPONENT(SPECIES_TAPU_LELE){ Level(76); Nature(NATURE_TIMID); Moves(MOVE_PSYCHIC, MOVE_THUNDERBOLT); Ability(ABILITY_PSYCHIC_SURGE); Speed(189); }
+        OPPONENT(SPECIES_IRON_LEAVES){ Level(76); Nature(NATURE_JOLLY); Moves(MOVE_PSYBLADE); Speed(206); }
+        OPPONENT(SPECIES_FARIGIRAF){ Level(76); Nature(NATURE_MODEST); Moves(MOVE_DAZZLING_GLEAM); Ability(ABILITY_PARENTAL_BOND); Speed(119); }
+        OPPONENT(SPECIES_ALAKAZAM){ Level(76); Nature(NATURE_TIMID); Moves(MOVE_FOCUS_BLAST); Speed(231); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_BUG_BITE, target:opponentRight);
+            SWITCH(playerRight, 2);
+            EXPECT_MOVE(opponentLeft, MOVE_PSYCHIC, target:playerRight);
+            EXPECT_MOVE(opponentRight, MOVE_PSYBLADE, target:playerRight);
+            EXPECT_SEND_OUT(opponentRight, 3);
+        }
+    }
+}


### PR DESCRIPTION
## Description
On current patch, Parental Bond is bugged where the battle engine correctly identifies Parental Bond not adding a second hit to spread moves, but the AI incorrectly sees that boost. This fix makes sure to check that a move should be boosted by Parental Bond at the AI damage calculation step for correct ability/damage awareness. 

In the provided test case, on current patch the AI sent out Farigiraf incorrectly vs Grimmsnarl seeing most damage with Dazzling Gleam (108 median w/o parental bond, 130 with) over Alakazam Focus Blast (119 median). In the test case, we now correctly get Alakazam in.

## Things to note in the release changelog:
- The AI no longer sees Parental Bond incorrectly applied to its damage calculations for spread moves in double battles.

## **Discord contact info**
ghostyboyy97
