### PR TITLE
fix (AI_FLAG_POWERFUL_STATUS): prevent reversing trick room in the hardcoded trick room fights

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2292,6 +2292,11 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             {
                 ADJUST_SCORE(-10);
             }
+            else if ((AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_POWERFUL_STATUS))
+            {
+                if (gFieldStatuses & STATUS_FIELD_TRICK_ROOM) // Trick Room Up, prevent reversing it
+                    ADJUST_SCORE(-10);
+            }
             else if (!(AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_POWERFUL_STATUS))
             {
                 if (gFieldStatuses & STATUS_FIELD_TRICK_ROOM) // Trick Room Up


### PR DESCRIPTION
## Description
We probably shouldn't let the player try and abuse Moltres/Victini into reversing trick room lol

## **People who collaborated with me in this PR**
Shoutout to Zay's NG+ E4 attempt (o7) for making me realize this condition was even possible

## Things to note in the release changelog:
- Fights with the Powerful Status flag will no longer try to reverse Trick Room in edge case scenarios

## **Discord contact info**
ghostyboyy97
