### PR TITLE
Items and berries restriction hard mode

### DIFF
--- a/data/scripts/berry_tree.inc
+++ b/data/scripts/berry_tree.inc
@@ -23,10 +23,18 @@ BerryTree_EventScript_Sparkling::
 BerryTree_EventScript_CheckSoil::
 	lock
 	faceplayer
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge BerryTree_EventScript_CheckSoilHard
 	specialvar VAR_RESULT, PlayerHasBerries
 	goto_if_eq VAR_RESULT, TRUE, BerryTree_EventScript_WantToPlant
 	specialvar VAR_RESULT, PlayerHasMulch
 	goto_if_eq VAR_RESULT, TRUE, BerryTree_EventScript_WantToMulch
+	message BerryTree_Text_ItsSoftLoamySoil
+	waitmessage
+	waitbuttonpress
+	release
+	end
+BerryTree_EventScript_CheckSoilHard:
 	message BerryTree_Text_ItsSoftLoamySoil
 	waitmessage
 	waitbuttonpress

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11468,7 +11468,7 @@ void TryRestoreHeldItems(void)
             //    lostItem = ITEM_NONE;
 
             // Check if the lost item should be restored
-            if (lostItem != ITEM_NONE || returnNPCItems)// && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
+            if (VarGet(VAR_GAME_SETTING_DIFFICULTY_MODE) < GAME_SETTING_DIFFICULTY_HARD_MODE &&(lostItem != ITEM_NONE || returnNPCItems))// && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);
         }
     }


### PR DESCRIPTION
## Description
- Items are permanently used in hard mode
- Items are permanently knocked off in hard mode 
- Berries can't be planted in hard mode

## **People who collaborated with me in this PR**
Whybo yapping on discord

## Things to note in the release changelog:
- Items are permanently used in hard mode
- Items are permanently knocked off in hard mode 
- Berries can't be planted in hard mode

## **Discord contact info**
MaximeGr
 
