### PR TITLE
feat (AI switching): logic refactor for more performant and robust switch-in calcs

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -345,12 +345,6 @@ struct AIPartyData // Opposing battlers - party mons.
     u8 count[NUM_BATTLE_SIDES];
 };
 
-struct SwitchinCandidate
-{
-    struct BattlePokemon battleMon;
-    bool8 hypotheticalStatus;
-};
-
 struct SimulatedDamage
 {
     u16 minimum;
@@ -375,7 +369,6 @@ struct AiLogicData
     u8 moveLimitations[MAX_BATTLERS_COUNT];
     u8 monToSwitchInId[MAX_BATTLERS_COUNT]; // ID of the mon to switch in.
     u8 mostSuitableMonId[MAX_BATTLERS_COUNT]; // Stores result of GetMostSuitableMonToSwitchInto, which decides which generic mon the AI would switch into if they decide to switch. This can be overruled by specific mons found in ShouldSwitch; the final resulting mon is stored in AI_monToSwitchIntoId.
-    struct SwitchinCandidate switchinCandidate; // Struct used for deciding which mon to switch to in battle_ai_switch_items.c
     u8 weatherHasEffect:1; // The same as WEATHER_HAS_EFFECT. Stored here, so it's called only once.
     u8 ejectButtonSwitch:1; // Tracks whether current switch out was from Eject Button
     u8 ejectPackSwitch:1; // Tracks whether current switch out was from Eject Pack

--- a/include/battle_ai_main.h
+++ b/include/battle_ai_main.h
@@ -121,6 +121,7 @@ void Ai_UpdateFaintData(u32 battler);
 void SetAiLogicDataForTurn(struct AiLogicData *aiData);
 void ResetDynamicAiFunc(void);
 u32 GetStatBeingLoweredFromMoveEffect(u32 statChange);
+void CalcBattlerAiMovesData(struct AiLogicData *aiData, u32 battlerAtk, u32 battlerDef, u32 weather);
 
 extern u8 sBattler_AI;
 

--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -45,7 +45,7 @@ void GetAIPartyIndexes(u32 battlerId, s32 *firstId, s32 *lastId);
 void AI_TrySwitchOrUseItem(u32 battler);
 u32 GetMostSuitableMonToSwitchInto(u32 battler, enum SwitchType switchType);
 bool32 ShouldSwitch(u32 battler);
-bool32 IsMonGrounded(u16 heldItemEffect, u32 ability, u8 type1, u8 type2);
+bool32 IsMonGrounded(u16 heldItemEffect, u32 ability, u32 battler);
 void ModifySwitchAfterMoveScoring(u32 battler);
 bool32 CanBattlerWin1v1(u32 hitsToKOAI, u32 hitsToKOPlayer, bool32 isBattlerFirst);
 bool32 CanAIWin1V1(u32 battlerAtk, u32 battlerDef);

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -117,7 +117,7 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId);
 u32 AI_DecideHoldEffectForTurn(u32 battlerId);
 bool32 DoesBattlerIgnoreAbilityChecks(u32 atkAbility, u32 move);
 u32 AI_GetWeather(struct AiLogicData *aiData);
-u32 AI_GetSwitchinWeather(struct BattlePokemon battleMon);
+u32 AI_GetSwitchinWeather(u32 battler);
 bool32 CanAIFaintTarget(u32 battlerAtk, u32 battlerDef, u32 numHits);
 bool32 CanIndexMoveFaintTarget(u32 battlerAtk, u32 battlerDef, u32 index, enum DamageCalcContext calcContext);
 bool32 HasDamagingMove(u32 battlerId);
@@ -270,6 +270,8 @@ bool32 ShouldUseWishAromatherapy(u32 battlerAtk, u32 battlerDef, u32 move);
 // party logic
 struct BattlePokemon *AllocSaveBattleMons(void);
 void FreeRestoreBattleMons(struct BattlePokemon *savedBattleMons);
+struct AiLogicData *AllocSaveAiLogicData(void);
+void FreeRestoreAiLogicData(struct AiLogicData *savedAiLogicData);
 s32 CountUsablePartyMons(u32 battlerId);
 bool32 IsPartyFullyHealedExceptBattler(u32 battler);
 bool32 PartyHasMoveCategory(u32 battlerId, u32 category);
@@ -288,8 +290,6 @@ void IncreaseFrostbiteScore(u32 battlerAtk, u32 battlerDef, u32 move, s32 *score
 bool32 HasHPForDamagingSetup(u32 battlerAtk, u32 battlerDef, u32 hpThreshold);
 //u32 IncreaseIndexMoveScoreBasedOnRolls(u32 battlerAtk, u32 battlerDef, u32 moveIndex);
 
-s32 AI_CalcPartyMonDamage(u32 move, u32 battlerAtk, u32 battlerDef, struct BattlePokemon switchinCandidate, enum DamageCalcContext calcContext);
-u32 AI_WhoStrikesFirstPartyMon(u32 battlerAtk, u32 battlerDef, struct BattlePokemon switchinCandidate, u32 aiMoveConsidered, u32 playerMoveConsidered, enum ConsiderPriority ConsiderPriority);
 s32 AI_TryToClearStats(u32 battlerAtk, u32 battlerDef, bool32 isDoubleBattle);
 bool32 AI_ShouldCopyStatChanges(u32 battlerAtk, u32 battlerDef);
 bool32 AI_ShouldSetUpHazards(u32 battlerAtk, u32 battlerDef, struct AiLogicData *aiData);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -409,7 +409,7 @@ static u32 Ai_SetMoveAccuracy(struct AiLogicData *aiData, u32 battlerAtk, u32 ba
     return accuracy;
 }
 
-static void CalcBattlerAiMovesData(struct AiLogicData *aiData, u32 battlerAtk, u32 battlerDef, u32 weather)
+void CalcBattlerAiMovesData(struct AiLogicData *aiData, u32 battlerAtk, u32 battlerDef, u32 weather)
 {
     u32 moveIndex, move;
     u16 *moves = GetMovesArray(battlerAtk);

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -27,15 +27,28 @@ static bool32 ShouldUseItem(u32 battler);
 static bool32 AiExpectsToFaintPlayer(u32 battler);
 static bool32 AI_ShouldHeal(u32 battler, u32 healAmount);
 static bool32 AI_OpponentCanFaintAiWithMod(u32 battler, u32 healAmount);
-static u32 GetSwitchinHazardsDamage(u32 battler, struct BattlePokemon *battleMon);
+static u32 GetSwitchinHazardsDamage(u32 battler);
 static bool32 AI_CanSwitchinAbilityTrapOpponent(u16 ability, u32 opposingBattler);
 static bool32 AreStatsRaised(u32 battler);
-static u32 GetBattleMonTypeMatchup(struct BattlePokemon opposingBattleMon, struct BattlePokemon battleMon);
+static u32 GetBattlerTypeMatchup(u32 opposingBattler, u32 battler);
 
-static void InitializeSwitchinCandidate(struct Pokemon *mon)
+static void InitializeSwitchinCandidate(u32 switchInBattler, struct Pokemon *mon)
 {
-    PokemonToBattleMon(mon, &AI_DATA->switchinCandidate.battleMon);
-    AI_DATA->switchinCandidate.hypotheticalStatus = FALSE;
+    PokemonToBattleMon(mon, &gBattleMons[switchInBattler]);
+    // Setup switchin battler data
+    AI_THINKING_STRUCT->saved[switchInBattler].saved = TRUE;
+    SetBattlerAiData(switchInBattler, AI_DATA);
+    // SetBattlerFieldStatusForSwitchin(battler);
+    for (u32 battler = 0; battler < gBattlersCount; battler++)
+    {
+        if (switchInBattler == battler || !IsBattlerAlive(battler))
+            continue;
+
+        CalcBattlerAiMovesData(AI_DATA, switchInBattler, battler, AI_GetSwitchinWeather(switchInBattler));
+        CalcBattlerAiMovesData(AI_DATA, battler, switchInBattler, AI_GetSwitchinWeather(switchInBattler));
+    }
+
+    AI_THINKING_STRUCT->saved[switchInBattler].saved = FALSE;
 }
 
 u32 GetSwitchChance(u32 shouldSwitchScenario)
@@ -151,8 +164,8 @@ static bool32 AI_DoesChoiceEffectBlockMove(u32 battler, u32 move)
     // Choice locked into something else
     if (AI_DATA->lastUsedMove[battler] != MOVE_NONE && AI_DATA->lastUsedMove[battler] != move
     && ((HOLD_EFFECT_CHOICE(GetBattlerHoldEffect(battler, FALSE)) && IsBattlerItemEnabled(battler))
-        || gBattleMons[battler].ability == ABILITY_GORILLA_TACTICS
-        || gBattleMons[battler].ability == ABILITY_SAGE_POWER))
+        || AI_DATA->abilities[battler] == ABILITY_GORILLA_TACTICS
+        || AI_DATA->abilities[battler] == ABILITY_SAGE_POWER))
         return TRUE;
     return FALSE;
 }
@@ -344,7 +357,7 @@ static bool32 ShouldSwitchIfHasBadOdds(u32 battler)
     }
 
     // Calculate type advantage
-    typeMatchup = GetBattleMonTypeMatchup(gBattleMons[opposingBattler], gBattleMons[battler]);
+    typeMatchup = GetBattlerTypeMatchup(opposingBattler, battler);
 
     oneShotDefenseCheck = ((gItemsInfo[gBattleMons[battler].item].holdEffect == HOLD_EFFECT_FOCUS_SASH)
                         || ((aiAbility == ABILITY_STURDY) && !IsMoldBreakerTypeAbility(opposingBattler, gBattleMons[opposingBattler].ability)));
@@ -475,8 +488,8 @@ static bool32 ShouldSwitchIfAllMovesBad(u32 battler)
         {
             aiMove = gBattleMons[battler].moves[moveIndex];
             if (AI_GetMoveEffectiveness(aiMove, battler, opposingBattler) > UQ_4_12(0.0) && aiMove != MOVE_NONE
-                && !CanAbilityAbsorbMove(battler, opposingBattler, gBattleMons[opposingBattler].ability, aiMove, GetMoveType(aiMove))
-                && !CanAbilityBlockMove(battler, opposingBattler, aiMove, gBattleMons[opposingBattler].ability)
+                && !CanAbilityAbsorbMove(battler, opposingBattler, AI_DATA->abilities[battler], aiMove, GetMoveType(aiMove))
+                && !CanAbilityBlockMove(battler, opposingBattler, aiMove, AI_DATA->abilities[battler])
                 && gMovesInfo[aiMove].power != 0)
                 return FALSE;
         }
@@ -631,7 +644,7 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
     // Check current mon for all absorbing abilities
     for (i = 0; i < numAbsorbingAbilities; i++)
     {
-        if (gBattleMons[battler].ability == absorbingTypeAbilities[i])
+        if (AI_DATA->abilities[battler] == absorbingTypeAbilities[i])
             return FALSE;
     }
 
@@ -879,7 +892,7 @@ static bool32 CanMonSurviveHazardSwitchin(u32 battler)
     if (ability == ABILITY_REGENERATOR)
         battlerHp = (battlerHp * 133) / 100; // Account for Regenerator healing
 
-    hazardDamage = GetSwitchinHazardsDamage(battler, &gBattleMons[battler]);
+    hazardDamage = GetSwitchinHazardsDamage(battler);
 
     // Battler will faint to hazards, check to see if another mon can clear them
     if (hazardDamage > battlerHp)
@@ -1125,11 +1138,12 @@ bool32 ShouldSwitch(u32 battler)
         return TRUE;
     if (ShouldSwitchIfAttackingStatsLowered(battler))
     {
+        DebugPrintf("can win 1v1 = %d", canAIWin1V1);
         if (!canAIWin1V1)
             return TRUE;
     }
 
-    // Removing switch capabilites under specific conditions
+    // Removing switch capabilities under specific conditions
     if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_SMART_SWITCHING)
         return FALSE;
     if (CanUseSuperEffectiveMoveAgainstOpponents(battler))
@@ -1339,123 +1353,10 @@ void AI_TrySwitchOrUseItem(u32 battler)
     BtlController_EmitTwoReturnValues(battler, BUFFER_B, B_ACTION_USE_MOVE, BATTLE_OPPOSITE(battler) << 8);
 }
 
-// If there are two(or more) mons to choose from, always choose one that has baton pass
-// as most often it can't do much on its own.
-static u32 GetBestMonBatonPass(struct Pokemon *party, int firstId, int lastId, u8 invalidMons, int aliveCount, u32 battler, u32 opposingBattler)
+bool32 IsMonGrounded(u16 heldItemEffect, u32 ability, u32 battler)
 {
-    int i, j, bits = 0;
-
-    for (i = firstId; i < lastId; i++)
-    {
-        if (invalidMons & (1u << i))
-            continue;
-
-        for (j = 0; j < MAX_MON_MOVES; j++)
-        {
-            if (GetMonData(&party[i], MON_DATA_MOVE1 + j, NULL) == MOVE_BATON_PASS)
-            {
-                bits |= 1u << i;
-                break;
-            }
-        }
-    }
-
-    if ((aliveCount == 2 || (aliveCount > 2 && Random() % 3 == 0)) && bits)
-    {
-        do
-        {
-            i = (Random() % (lastId - firstId)) + firstId;
-        } while (!(bits & (1 << i)));
-        return i;
-    }
-
-    return PARTY_SIZE;
-}
-
-static u32 GetBestMonTypeMatchup(struct Pokemon *party, int firstId, int lastId, u8 invalidMons, u32 battler, u32 opposingBattler)
-{
-    int i, bits = 0;
-
-    while (bits != 0x3F) // All mons were checked.
-    {
-        u32 bestResist = UQ_4_12(2.0);
-        int bestMonId = PARTY_SIZE;
-        // Find the mon whose type is the most suitable defensively.
-        for (i = firstId; i < lastId; i++)
-        {
-            if (!((1u << i) & invalidMons) && !((1u << i) & bits))
-            {
-                InitializeSwitchinCandidate(&party[i]);
-
-                u32 typeEffectiveness = GetBattleMonTypeMatchup(gBattleMons[opposingBattler], AI_DATA->switchinCandidate.battleMon);
-                if (typeEffectiveness < bestResist)
-                {
-                    bestResist = typeEffectiveness;
-                    bestMonId = i;
-                }
-            }
-        }
-
-        // Ok, we know the mon has the right typing but does it have at least one super effective move?
-        if (bestMonId != PARTY_SIZE)
-        {
-            for (i = 0; i < MAX_MON_MOVES; i++)
-            {
-                u32 move = GetMonData(&party[bestMonId], MON_DATA_MOVE1 + i);
-                if (move != MOVE_NONE && AI_GetMoveEffectiveness(move, battler, opposingBattler) >= UQ_4_12(2.0))
-                    break;
-            }
-
-            if (i != MAX_MON_MOVES)
-                return bestMonId; // Has both the typing and at least one super effective move.
-
-            bits |= (1u << bestMonId); // Sorry buddy, we want something better.
-        }
-        else
-        {
-            bits = 0x3F; // No viable mon to switch.
-        }
-    }
-
-    return PARTY_SIZE;
-}
-
-static u32 GetBestMonDmg(struct Pokemon *party, int firstId, int lastId, u8 invalidMons, u32 battler, u32 opposingBattler)
-{
-    int i, j;
-    int dmg, bestDmg = 0;
-    int bestMonId = PARTY_SIZE;
-
-    u32 aiMove;
-
-    gMoveResultFlags = 0;
-    // If we couldn't find the best mon in terms of typing, find the one that deals most damage.
-    for (i = firstId; i < lastId; i++)
-    {
-        if ((1 << (i)) & invalidMons)
-            continue;
-        InitializeSwitchinCandidate(&party[i]);
-        for (j = 0; j < MAX_MON_MOVES; j++)
-        {
-            aiMove = AI_DATA->switchinCandidate.battleMon.moves[j];
-            if (aiMove != MOVE_NONE && gMovesInfo[aiMove].power != 0)
-            {
-                aiMove = GetMonData(&party[i], MON_DATA_MOVE1 + j);
-                dmg = AI_CalcPartyMonDamage(aiMove, battler, opposingBattler, AI_DATA->switchinCandidate.battleMon, AI_ATTACKING_IN_SWITCHIN_CALC);
-                if (bestDmg < dmg)
-                {
-                    bestDmg = dmg;
-                    bestMonId = i;
-                }
-            }
-        }
-    }
-
-    return bestMonId;
-}
-
-bool32 IsMonGrounded(u16 heldItemEffect, u32 ability, u8 type1, u8 type2)
-{
+    u8 type1 = gBattleMons[battler].types[0];
+    u8 type2 = gBattleMons[battler].types[1];
     // List that makes mon not grounded
     if (type1 == TYPE_FLYING || type2 == TYPE_FLYING || ability == ABILITY_LEVITATE
          || (heldItemEffect == HOLD_EFFECT_AIR_BALLOON && !(ability == ABILITY_KLUTZ || (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM))))
@@ -1471,11 +1372,12 @@ bool32 IsMonGrounded(u16 heldItemEffect, u32 ability, u8 type1, u8 type2)
 }
 
 // Gets hazard damage
-static u32 GetSwitchinHazardsDamage(u32 battler, struct BattlePokemon *battleMon)
+static u32 GetSwitchinHazardsDamage(u32 battler)
 {
-    u8 defType1 = battleMon->types[0], defType2 = battleMon->types[1], tSpikesLayers;
-    u16 heldItemEffect = ItemId_GetHoldEffect(battleMon->item);
-    u32 maxHP = battleMon->maxHP, ability = battleMon->ability, status = battleMon->status1;
+    // u8 defType1 = battleMon->types[0], defType2 = battleMon->types[1];
+    u8 tSpikesLayers;
+    u16 heldItemEffect = AI_DATA->holdEffects[battler];
+    u32 maxHP = gBattleMons[battler].maxHP, ability = AI_DATA->abilities[battler], status = gBattleMons[battler].status1;
     u32 spikesDamage = 0, tSpikesDamage = 0, hazardDamage = 0;
     u32 hazardFlags = gSideStatuses[GetBattlerSide(battler)] & (SIDE_STATUS_SPIKES | SIDE_STATUS_STEALTH_ROCK | SIDE_STATUS_STICKY_WEB | SIDE_STATUS_TOXIC_SPIKES | SIDE_STATUS_SAFEGUARD);
 
@@ -1485,12 +1387,12 @@ static u32 GetSwitchinHazardsDamage(u32 battler, struct BattlePokemon *battleMon
     {
         // Stealth Rock
         if ((hazardFlags & SIDE_STATUS_STEALTH_ROCK) && heldItemEffect != HOLD_EFFECT_HEAVY_DUTY_BOOTS && ability != ABILITY_MOUNTAINEER)
-            hazardDamage += GetStealthHazardDamageByTypesAndHP(gMovesInfo[MOVE_STEALTH_ROCK].type, defType1, defType2, battleMon->maxHP);
+            hazardDamage += GetStealthHazardDamage(gMovesInfo[MOVE_STEALTH_ROCK].type, battler);
         // G-Max Steelsurge
         if ((hazardFlags & SIDE_STATUS_STEELSURGE) && heldItemEffect != HOLD_EFFECT_HEAVY_DUTY_BOOTS)
-            hazardDamage += GetStealthHazardDamageByTypesAndHP(gMovesInfo[MOVE_G_MAX_STEELSURGE].type, defType1, defType2, battleMon->maxHP);
+            hazardDamage += GetStealthHazardDamage(gMovesInfo[MOVE_G_MAX_STEELSURGE].type, battler);
         // Spikes
-        if ((hazardFlags & SIDE_STATUS_SPIKES) && IsMonGrounded(heldItemEffect, ability, defType1, defType2))
+        if ((hazardFlags & SIDE_STATUS_SPIKES) && IsMonGrounded(heldItemEffect, ability, battler))
         {
             spikesDamage = maxHP / ((5 - gSideTimers[GetBattlerSide(battler)].spikesAmount) * 2);
             if (spikesDamage == 0)
@@ -1498,8 +1400,7 @@ static u32 GetSwitchinHazardsDamage(u32 battler, struct BattlePokemon *battleMon
             hazardDamage += spikesDamage;
         }
 
-        if ((hazardFlags & SIDE_STATUS_TOXIC_SPIKES) && (defType1 != TYPE_POISON && defType2 != TYPE_POISON
-            && defType1 != TYPE_STEEL && defType2 != TYPE_STEEL
+        if ((hazardFlags & SIDE_STATUS_TOXIC_SPIKES) && (!IS_BATTLER_ANY_TYPE(battler, TYPE_POISON, TYPE_STEEL)
             && ability != ABILITY_IMMUNITY && ability != ABILITY_POISON_HEAL && ability != ABILITY_COMATOSE
             && status == 0
             && !(hazardFlags & SIDE_STATUS_SAFEGUARD)
@@ -1507,7 +1408,7 @@ static u32 GetSwitchinHazardsDamage(u32 battler, struct BattlePokemon *battleMon
             && !(IsBattlerTerrainAffected(battler, STATUS_FIELD_MISTY_TERRAIN))
             && !(IsAbilityStatusProtected(battler))
             && heldItemEffect != HOLD_EFFECT_CURE_PSN && heldItemEffect != HOLD_EFFECT_CURE_STATUS
-            && IsMonGrounded(heldItemEffect, ability, defType1, defType2)))
+            && IsMonGrounded(heldItemEffect, ability, battler)))
         {
             tSpikesLayers = gSideTimers[GetBattlerSide(battler)].toxicSpikesAmount;
             if (tSpikesLayers == 1)
@@ -1528,32 +1429,33 @@ static u32 GetSwitchinHazardsDamage(u32 battler, struct BattlePokemon *battleMon
     return hazardDamage;
 }
 
-static s32 GetSwitchInTerrainImpact(u16 heldItemEffect)
+static s32 GetSwitchInTerrainImpact(u32 battler)
 {
-    s32 terrainImpact = 0, maxHP = AI_DATA->switchinCandidate.battleMon.maxHP, ability = AI_DATA->switchinCandidate.battleMon.ability;
+    s32 terrainImpact = 0, maxHP = gBattleMons[battler].maxHP, ability = AI_DATA->abilities[battler];
+    u32 holdEffect = AI_DATA->holdEffects[battler];
     if (gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN)
     {
         // make sure switch-in candidate isn't grounded
             // air balloon = false, flying type = false, levitate = false
             // iron ball or gravity would force those to be true
-        bool32 isAirborne = heldItemEffect == HOLD_EFFECT_AIR_BALLOON || ability == ABILITY_LEVITATE || AI_DATA->switchinCandidate.battleMon.types[0] == TYPE_FLYING || AI_DATA->switchinCandidate.battleMon.types[1] == TYPE_FLYING;
-        if (heldItemEffect == HOLD_EFFECT_IRON_BALL || (gFieldStatuses & STATUS_FIELD_GRAVITY) || !isAirborne)
+        bool32 isAirborne = holdEffect == HOLD_EFFECT_AIR_BALLOON || ability == ABILITY_LEVITATE || IS_BATTLER_OF_TYPE(battler, TYPE_FLYING);
+        if (holdEffect == HOLD_EFFECT_IRON_BALL || (gFieldStatuses & STATUS_FIELD_GRAVITY) || !isAirborne)
         {
             terrainImpact = maxHP / 16;
             if (terrainImpact == 0)
                 terrainImpact = 1;
         }
-        
     }
 
     return terrainImpact;
 }
 
 // Gets damage / healing from weather
-static s32 GetSwitchinWeatherImpact(void)
+static s32 GetSwitchinWeatherImpact(u32 battler)
 {
-    s32 weatherImpact = 0, maxHP = AI_DATA->switchinCandidate.battleMon.maxHP, ability = AI_DATA->switchinCandidate.battleMon.ability;
-    u32 holdEffect = ItemId_GetHoldEffect(AI_DATA->switchinCandidate.battleMon.item);
+    s32 weatherImpact = 0, maxHP = gBattleMons[battler].maxHP;
+    u32 ability = AI_DATA->abilities[battler];
+    u32 holdEffect = AI_DATA->holdEffects[battler];
 
     if (WEATHER_HAS_EFFECT)
     {
@@ -1561,7 +1463,7 @@ static s32 GetSwitchinWeatherImpact(void)
         if (holdEffect != HOLD_EFFECT_SAFETY_GOGGLES && ability != ABILITY_MAGIC_GUARD && ability != ABILITY_OVERCOAT)
         {
             if ((gBattleWeather & B_WEATHER_HAIL)
-             && (AI_DATA->switchinCandidate.battleMon.types[0] != TYPE_ICE || AI_DATA->switchinCandidate.battleMon.types[1] != TYPE_ICE)
+             && IS_BATTLER_OF_TYPE(battler, TYPE_ICE)
              && ability != ABILITY_SNOW_CLOAK && ability != ABILITY_ICE_BODY)
             {
                 weatherImpact = maxHP / 16;
@@ -1569,10 +1471,8 @@ static s32 GetSwitchinWeatherImpact(void)
                     weatherImpact = 1;
             }
             else if ((gBattleWeather & B_WEATHER_SANDSTORM)
-                && (AI_DATA->switchinCandidate.battleMon.types[0] != TYPE_GROUND && AI_DATA->switchinCandidate.battleMon.types[1] != TYPE_GROUND
-                && AI_DATA->switchinCandidate.battleMon.types[0] != TYPE_ROCK && AI_DATA->switchinCandidate.battleMon.types[1] != TYPE_ROCK
-                && AI_DATA->switchinCandidate.battleMon.types[0] != TYPE_STEEL && AI_DATA->switchinCandidate.battleMon.types[1] != TYPE_STEEL
-                && ability != ABILITY_SAND_VEIL && ability != ABILITY_SAND_RUSH && ability != ABILITY_SAND_FORCE))
+                && IS_BATTLER_ANY_TYPE(battler, TYPE_ROCK, TYPE_GROUND, TYPE_STEEL)
+                && ability != ABILITY_SAND_VEIL && ability != ABILITY_SAND_RUSH && ability != ABILITY_SAND_FORCE)
             {
                 weatherImpact = maxHP / 16;
                 if (weatherImpact == 0)
@@ -1614,15 +1514,15 @@ static s32 GetSwitchinWeatherImpact(void)
 }
 
 // Gets one turn of recurring healing
-static u32 GetSwitchinRecurringHealing(void)
+static u32 GetSwitchinRecurringHealing(u32 battler)
 {
-    u32 recurringHealing = 0, maxHP = AI_DATA->switchinCandidate.battleMon.maxHP, ability = AI_DATA->switchinCandidate.battleMon.ability;
-    u32 holdEffect = ItemId_GetHoldEffect(AI_DATA->switchinCandidate.battleMon.item);
+    u32 recurringHealing = 0, maxHP = gBattleMons[battler].maxHP, ability = AI_DATA->abilities[battler];
+    u32 holdEffect = AI_DATA->holdEffects[battler];
 
     // Items
     if (ability != ABILITY_KLUTZ)
     {
-        if (holdEffect == HOLD_EFFECT_BLACK_SLUDGE && (AI_DATA->switchinCandidate.battleMon.types[0] == TYPE_POISON || AI_DATA->switchinCandidate.battleMon.types[1] == TYPE_POISON))
+        if (holdEffect == HOLD_EFFECT_BLACK_SLUDGE && IS_BATTLER_OF_TYPE(battler, TYPE_POISON))
         {
             recurringHealing = maxHP / 16;
             if (recurringHealing == 0)
@@ -1637,7 +1537,7 @@ static u32 GetSwitchinRecurringHealing(void)
     } // Intentionally omitting Shell Bell for its inconsistency
 
     // Abilities
-    if (ability == ABILITY_POISON_HEAL && (AI_DATA->switchinCandidate.battleMon.status1 & STATUS1_POISON))
+    if (ability == ABILITY_POISON_HEAL && (gBattleMons[battler].status1 & STATUS1_POISON))
     {
         u32 healing = maxHP / 8;
         if (healing == 0)
@@ -1648,14 +1548,15 @@ static u32 GetSwitchinRecurringHealing(void)
 }
 
 // Gets one turn of recurring damage
-static u32 GetSwitchinRecurringDamage(u16 holdEffect)
+static u32 GetSwitchinRecurringDamage(u32 battler)
 {
-    u32 passiveDamage = 0, maxHP = AI_DATA->switchinCandidate.battleMon.maxHP, ability = AI_DATA->switchinCandidate.battleMon.ability;
+    u32 passiveDamage = 0, maxHP = gBattleMons[battler].maxHP, ability = AI_DATA->abilities[battler];
+    u32 holdEffect = AI_DATA->holdEffects[battler];
 
     // Items
     if (ability != ABILITY_MAGIC_GUARD && ability != ABILITY_KLUTZ)
     {
-        if (holdEffect == HOLD_EFFECT_BLACK_SLUDGE && AI_DATA->switchinCandidate.battleMon.types[0] != TYPE_POISON && AI_DATA->switchinCandidate.battleMon.types[1] != TYPE_POISON)
+        if (holdEffect == HOLD_EFFECT_BLACK_SLUDGE && IS_BATTLER_OF_TYPE(battler, TYPE_POISON))
         {
             passiveDamage = maxHP / 8;
             if (passiveDamage == 0)
@@ -1680,14 +1581,13 @@ static u32 GetSwitchinRecurringDamage(u16 holdEffect)
 // Gets one turn of status damage
 static u32 GetSwitchinStatusDamage(u32 battler)
 {
-    u8 defType1 = AI_DATA->switchinCandidate.battleMon.types[0], defType2 = AI_DATA->switchinCandidate.battleMon.types[1];
     u8 tSpikesLayers = gSideTimers[GetBattlerSide(battler)].toxicSpikesAmount;
-    u16 heldItemEffect = ItemId_GetHoldEffect(AI_DATA->switchinCandidate.battleMon.item);
-    u32 status = AI_DATA->switchinCandidate.battleMon.status1, ability = AI_DATA->switchinCandidate.battleMon.ability, maxHP = AI_DATA->switchinCandidate.battleMon.maxHP;
+    u16 heldItemEffect = AI_DATA->holdEffects[battler];
+    u32 status = gBattleMons[battler].status1, ability = AI_DATA->abilities[battler], maxHP = gBattleMons[battler].maxHP;
     u32 statusDamage = 0;
 
     // Status condition damage
-    if ((status != 0) && AI_DATA->switchinCandidate.battleMon.ability != ABILITY_MAGIC_GUARD)
+    if ((status != 0) && ability != ABILITY_MAGIC_GUARD)
     {
         if (status & STATUS1_BURN)
         {
@@ -1718,34 +1618,32 @@ static u32 GetSwitchinStatusDamage(u32 battler)
         else if ((status & STATUS1_TOXIC_POISON) && ability != ABILITY_POISON_HEAL)
         {
             if ((status & STATUS1_TOXIC_COUNTER) != STATUS1_TOXIC_TURN(15)) // not 16 turns
-                AI_DATA->switchinCandidate.battleMon.status1 += STATUS1_TOXIC_TURN(1);
+                gBattleMons[battler].status1 += STATUS1_TOXIC_TURN(1);
             statusDamage = maxHP / 16;
             if (statusDamage == 0)
                 statusDamage = 1;
-            statusDamage *= AI_DATA->switchinCandidate.battleMon.status1 & STATUS1_TOXIC_COUNTER >> 8;
+            statusDamage *= gBattleMons[battler].status1 & STATUS1_TOXIC_COUNTER >> 8;
         }
     }
 
     // Apply hypothetical poisoning from Toxic Spikes, which means the first turn of damage already added in GetSwitchinHazardsDamage
     // Do this last to skip one iteration of Poison / Toxic damage, and start counting Toxic damage one turn later.
-    if (tSpikesLayers != 0 && (defType1 != TYPE_POISON && defType2 != TYPE_POISON
+    if (tSpikesLayers != 0 && (IS_BATTLER_OF_TYPE(battler, TYPE_POISON)
         && ability != ABILITY_IMMUNITY && ability != ABILITY_POISON_HEAL
         && status == 0
         && !(heldItemEffect == HOLD_EFFECT_HEAVY_DUTY_BOOTS
             && (((gFieldStatuses & STATUS_FIELD_MAGIC_ROOM) || ability == ABILITY_KLUTZ)))
         && heldItemEffect != HOLD_EFFECT_CURE_PSN && heldItemEffect != HOLD_EFFECT_CURE_STATUS
-        && IsMonGrounded(heldItemEffect, ability, defType1, defType2)))
+        && IsMonGrounded(heldItemEffect, ability, battler)))
     {
         if (tSpikesLayers == 1)
         {
-            AI_DATA->switchinCandidate.battleMon.status1 = STATUS1_POISON; // Assign "hypothetical" status to the switchin candidate so we can get the damage it would take from TSpikes
-            AI_DATA->switchinCandidate.hypotheticalStatus = TRUE;
+            gBattleMons[battler].status1 = STATUS1_POISON; // Assign "hypothetical" status to the switchin candidate so we can get the damage it would take from TSpikes
         }
         if (tSpikesLayers == 2)
         {
-            AI_DATA->switchinCandidate.battleMon.status1 = STATUS1_TOXIC_POISON; // Assign "hypothetical" status to the switchin candidate so we can get the damage it would take from TSpikes
-            AI_DATA->switchinCandidate.battleMon.status1 += STATUS1_TOXIC_TURN(1);
-            AI_DATA->switchinCandidate.hypotheticalStatus = TRUE;
+            gBattleMons[battler].status1 = STATUS1_TOXIC_POISON; // Assign "hypothetical" status to the switchin candidate so we can get the damage it would take from TSpikes
+            gBattleMons[battler].status1 += STATUS1_TOXIC_TURN(1);
         }
     }
     return statusDamage;
@@ -1754,18 +1652,18 @@ static u32 GetSwitchinStatusDamage(u32 battler)
 // Gets number of hits to KO factoring in hazards, healing held items, status, and weather
 static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler, bool32 isFreeSwitch)
 {
-    u32 startingHP = AI_DATA->switchinCandidate.battleMon.hp - GetSwitchinHazardsDamage(battler, &AI_DATA->switchinCandidate.battleMon);
-    u16 heldItemEffect = ItemId_GetHoldEffect(AI_DATA->switchinCandidate.battleMon.item);
-    s32 weatherImpact = GetSwitchinWeatherImpact(); // Signed to handle both damage and healing in the same value
-    s32 terrainImpact = GetSwitchInTerrainImpact(heldItemEffect);
-    u32 recurringHeldItemDamage = GetSwitchinRecurringDamage(heldItemEffect);
-    u32 recurringHealing = GetSwitchinRecurringHealing();
+    u32 startingHP = gBattleMons[battler].hp - GetSwitchinHazardsDamage(battler);
+    u16 heldItemEffect = AI_DATA->holdEffects[battler];
+    s32 weatherImpact = GetSwitchinWeatherImpact(battler); // Signed to handle both damage and healing in the same value
+    s32 terrainImpact = GetSwitchInTerrainImpact(battler);
+    u32 recurringHeldItemDamage = GetSwitchinRecurringDamage(battler);
+    u32 recurringHealing = GetSwitchinRecurringHealing(battler);
     u32 statusDamage = GetSwitchinStatusDamage(battler);
     u32 hitsToKO = 0;
-    u16 maxHP = AI_DATA->switchinCandidate.battleMon.maxHP, item = AI_DATA->switchinCandidate.battleMon.item;
+    u16 maxHP = gBattleMons[battler].maxHP, item = gBattleMons[battler].item;
     u8 weatherDuration = gWishFutureKnock.weatherDuration, terrainDuration = gFieldTimers.terrainTimer, holdEffectParam = ItemId_GetHoldEffectParam(item);
     u32 opposingBattler = GetBattlerAtPosition(BATTLE_OPPOSITE(GetBattlerPosition(battler)));
-    u32 opposingAbility = gBattleMons[opposingBattler].ability, ability = AI_DATA->switchinCandidate.battleMon.ability;
+    u32 opposingAbility = gBattleMons[opposingBattler].ability, ability = AI_DATA->abilities[battler];
     bool32 usedSingleUseHealingItem = FALSE, opponentCanBreakMold = IsMoldBreakerTypeAbility(opposingBattler, opposingAbility);
     s32 currentHP = startingHP, singleUseItemHeal = 0;
 
@@ -1803,7 +1701,7 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler, bool32 isFreeSwitch
             currentHP = currentHP - weatherImpact;
 
         // Check if we're at a single use healing item threshold
-        if (currentHP > 0 && AI_DATA->switchinCandidate.battleMon.ability != ABILITY_KLUTZ && usedSingleUseHealingItem == FALSE
+        if (currentHP > 0 && AI_DATA->abilities[battler] != ABILITY_KLUTZ && usedSingleUseHealingItem == FALSE
             && !(opposingAbility == ABILITY_UNNERVE && GetPocketByItemId(item) == POCKET_BERRIES))
         {
             switch (heldItemEffect)
@@ -1862,7 +1760,7 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler, bool32 isFreeSwitch
         }
 
         // Recalculate toxic damage if needed
-        if (AI_DATA->switchinCandidate.battleMon.status1 & STATUS1_TOXIC_POISON)
+        if (gBattleMons[battler].status1 & STATUS1_TOXIC_POISON)
             statusDamage = GetSwitchinStatusDamage(battler);
 
         // Reduce weather duration
@@ -1877,24 +1775,18 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler, bool32 isFreeSwitch
     }
 
     // Disguise will always add an extra hit to KO
-    if (!opponentCanBreakMold && AI_DATA->switchinCandidate.battleMon.species == SPECIES_MIMIKYU_DISGUISED)
+    if (!opponentCanBreakMold && gBattleMons[battler].species == SPECIES_MIMIKYU_DISGUISED)
         hitsToKO++;
 
-    // If mon had a hypothetical status from TSpikes, clear it
-    if (AI_DATA->switchinCandidate.hypotheticalStatus == TRUE)
-    {
-        AI_DATA->switchinCandidate.battleMon.status1 = 0;
-        AI_DATA->switchinCandidate.hypotheticalStatus = FALSE;
-    }
     return hitsToKO;
 }
 
-static u32 GetBattleMonTypeMatchup(struct BattlePokemon opposingBattleMon, struct BattlePokemon battleMon)
+static u32 GetBattlerTypeMatchup(u32 opposingBattler, u32 battler)
 {
     // Check type matchup
     u32 typeEffectiveness1 = UQ_4_12(1.0), typeEffectiveness2 = UQ_4_12(1.0);
-    u8 atkType1 = opposingBattleMon.types[0], atkType2 = opposingBattleMon.types[1],
-    defType1 = battleMon.types[0], defType2 = battleMon.types[1];
+    u8 atkType1 = gBattleMons[battler].types[0], atkType2 = gBattleMons[battler].types[1],
+    defType1 = gBattleMons[battler].types[0], defType2 = gBattleMons[battler].types[1];
 
     // Add each independent defensive type matchup together
     typeEffectiveness1 = uq4_12_multiply(typeEffectiveness1, (GetTypeModifier(atkType1, defType1)));
@@ -1939,7 +1831,7 @@ static int GetRandomSwitchinWithBatonPass(int aliveCount, int bits, int firstId,
         return PARTY_SIZE;
 }
 
-static s32 GetMaxDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposingBattler, struct BattlePokemon battleMon, u32 *bestPlayerMove)
+static s32 GetMaxDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposingBattler, u32 *bestPlayerMove)
 {
     int i = 0;
     u32 playerMove;
@@ -1952,7 +1844,7 @@ static s32 GetMaxDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposingBattle
             && gMovesInfo[playerMove].effect 
             && gBattleMons[opposingBattler].pp[i] > 0)
         {
-            damageTaken = AI_CalcPartyMonDamage(playerMove, opposingBattler, battler, battleMon, AI_DEFENDING_NORMAL);
+            damageTaken = AI_GetDamage(opposingBattler, battler, i, AI_DEFENDING_NORMAL, AI_DATA);
             if (playerMove == gBattleStruct->choicedMove[opposingBattler]) // If player is choiced, only care about the choice locked move
             {
                 *bestPlayerMove = playerMove;
@@ -1971,7 +1863,7 @@ static s32 GetMaxDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposingBattle
     return maxDamageTaken;
 }
 
-static s32 GetMaxPriorityDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposingBattler, struct BattlePokemon battleMon, u32 *bestPlayerPriorityMove)
+static s32 GetMaxPriorityDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposingBattler, u32 *bestPlayerPriorityMove)
 {
     int i = 0;
     u32 playerMove;
@@ -1979,7 +1871,7 @@ static s32 GetMaxPriorityDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposi
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         // If player is choiced into a non-priority move, AI understands that it can't deal priority damage
-        if (gBattleStruct->choicedMove[opposingBattler] !=MOVE_NONE && GetMovePriority(opposingBattler,gBattleStruct->choicedMove[opposingBattler]) < 1)
+        if (gBattleStruct->choicedMove[opposingBattler] != MOVE_NONE && GetMovePriority(opposingBattler, gBattleStruct->choicedMove[opposingBattler]) < 1)
             break;
         playerMove = gBattleMons[opposingBattler].moves[i];
         if (playerMove != MOVE_NONE
@@ -1988,7 +1880,7 @@ static s32 GetMaxPriorityDamagePlayerCouldDealToSwitchin(u32 battler, u32 opposi
             && gMovesInfo[playerMove].effect != EFFECT_FOCUS_PUNCH
             && gBattleMons[opposingBattler].pp[i] > 0)
         {
-            damageTaken = AI_CalcPartyMonDamage(playerMove, opposingBattler, battler, battleMon, AI_DEFENDING_NORMAL);
+            damageTaken = AI_GetDamage(opposingBattler, battler, i, AI_DEFENDING_NORMAL, AI_DATA);
             if (playerMove == gBattleStruct->choicedMove[opposingBattler]) // If player is choiced, only care about the choice locked move
             {
                 *bestPlayerPriorityMove = playerMove;
@@ -2086,14 +1978,17 @@ static inline bool32 CanSwitchinWin1v1(u32 hitsToKOAI, u32 hitsToKOPlayer, bool3
 // Everything runs in the same loop to minimize computation time. This makes it harder to read, but hopefully the comments can guide you!
 static u32 GetBestMonIntegrated(struct Pokemon *party, int firstId, int lastId, u32 battler, u32 opposingBattler, u32 battlerIn1, u32 battlerIn2, enum SwitchType switchType)
 {
-    int revengeKillerId = PARTY_SIZE, slowRevengeKillerId = PARTY_SIZE, fastThreatenId = PARTY_SIZE, slowThreatenId = PARTY_SIZE, damageMonId = PARTY_SIZE, generic1v1MonId = PARTY_SIZE;;
+    int revengeKillerId = PARTY_SIZE, slowRevengeKillerId = PARTY_SIZE, fastThreatenId = PARTY_SIZE, slowThreatenId = PARTY_SIZE, damageMonId = PARTY_SIZE, generic1v1MonId = PARTY_SIZE;
     int batonPassId = PARTY_SIZE, defensiveMonId = PARTY_SIZE, aceMonId = PARTY_SIZE, trapperId = PARTY_SIZE;
     int i, j, aliveCount = 0, bits = 0, aceMonCount = 0;
     s32 defensiveMonHitKOThreshold = 3; // 3HKO threshold that candidate defensive mons must exceed
     s32 playerMonHP = gBattleMons[opposingBattler].hp, maxDamageDealt = 0, damageDealt = 0;
     u32 aiMove, hitsToKOAI, hitsToKOPlayer, hitsToKOAIPriority, bestPlayerMove = MOVE_NONE, bestPlayerPriorityMove = MOVE_NONE, maxHitsToKO = 0;
     bool32 isFreeSwitch = IsFreeSwitch(switchType, battlerIn1, opposingBattler), isSwitchinFirst, isSwitchinFirstPriority, canSwitchinWin1v1;
-    u32 storeCurrBattlerPartyIndex = gBattlerPartyIndexes[battler]; //Rage Fist fix 
+    u32 storeCurrBattlerPartyIndex = gBattlerPartyIndexes[battler]; //Rage Fist fix
+
+    struct AiLogicData *savedAiLogicData = AllocSaveAiLogicData();
+    struct BattlePokemon *savedBattleMons = AllocSaveBattleMons();
 
     // Iterate through mons
     for (i = firstId; i < lastId; i++)
@@ -2118,33 +2013,35 @@ static u32 GetBestMonIntegrated(struct Pokemon *party, int firstId, int lastId, 
             aliveCount++;
 
         gBattlerPartyIndexes[battler] = i; // Rage Fist fix
-        InitializeSwitchinCandidate(&party[i]);
+        InitializeSwitchinCandidate(battler, &party[i]);
+
+        // TODO - pull GetIncomingHealInfo from upstream?
 
         // While not really invalid per se, not really wise to switch into this mon
-        if (AI_DATA->switchinCandidate.battleMon.ability == ABILITY_TRUANT && IsTruantMonVulnerable(battler, opposingBattler))
+        if (AI_DATA->abilities[battler] == ABILITY_TRUANT && IsTruantMonVulnerable(battler, opposingBattler))
             continue;
 
         AI_DATA->switchInCalc = TRUE;
 
         // Get max number of hits for player to KO AI mon and type matchup for defensive switching
-        hitsToKOAI = GetSwitchinHitsToKO(GetMaxDamagePlayerCouldDealToSwitchin(battler, opposingBattler, AI_DATA->switchinCandidate.battleMon, &bestPlayerMove), battler, isFreeSwitch);
-        hitsToKOAIPriority = GetSwitchinHitsToKO(GetMaxPriorityDamagePlayerCouldDealToSwitchin(battler, opposingBattler, AI_DATA->switchinCandidate.battleMon, &bestPlayerPriorityMove), battler, isFreeSwitch);
+        hitsToKOAI = GetSwitchinHitsToKO(GetMaxDamagePlayerCouldDealToSwitchin(battler, opposingBattler, &bestPlayerMove), battler, isFreeSwitch);
+        hitsToKOAIPriority = GetSwitchinHitsToKO(GetMaxPriorityDamagePlayerCouldDealToSwitchin(battler, opposingBattler, &bestPlayerPriorityMove), battler, isFreeSwitch);
 
         // Check through current mon's moves
         for (j = 0; j < MAX_MON_MOVES; j++)
         {
             // Check that move has PP remaining before running calcs
-            if (AI_DATA->switchinCandidate.battleMon.pp[j] < 1)
+            if (gBattleMons[battler].pp[j] < 1)
                 continue;
             
-            aiMove = AI_DATA->switchinCandidate.battleMon.moves[j];
-            damageDealt = AI_CalcPartyMonDamage(aiMove, battler, opposingBattler, AI_DATA->switchinCandidate.battleMon, AI_ATTACKING_IN_SWITCHIN_CALC);
-            hitsToKOPlayer = GetNoOfHitsToKOBattlerDmg(damageDealt, opposingBattler);
+            aiMove = gBattleMons[battler].moves[j];
+            damageDealt = AI_GetDamage(battler, opposingBattler, j, AI_ATTACKING_IN_SWITCHIN_CALC, AI_DATA);
+            hitsToKOPlayer = GetNoOfHitsToKOBattler(battler, opposingBattler, j, AI_ATTACKING_IN_SWITCHIN_CALC, CONSIDER_ENDURE);
             gBattlerPartyIndexes[battler] = storeCurrBattlerPartyIndex; // Rage Fist fix
             
             // Offensive switchin decisions are based on which whether switchin moves first and whether it can win a 1v1
-            isSwitchinFirst = AI_IsPartyMonFaster(battler, opposingBattler, AI_DATA->switchinCandidate.battleMon, aiMove, bestPlayerMove, CONSIDER_PRIORITY);
-            isSwitchinFirstPriority = AI_IsPartyMonFaster(battler, opposingBattler, AI_DATA->switchinCandidate.battleMon, aiMove, bestPlayerPriorityMove, CONSIDER_PRIORITY);
+            isSwitchinFirst = AI_IsFaster(battler, opposingBattler, aiMove, bestPlayerMove, CONSIDER_PRIORITY);
+            isSwitchinFirstPriority = AI_IsFaster(battler, opposingBattler, aiMove, bestPlayerPriorityMove, CONSIDER_PRIORITY);
             canSwitchinWin1v1 = CanSwitchinWin1v1(hitsToKOAI, hitsToKOPlayer, isSwitchinFirst, isFreeSwitch) && CanSwitchinWin1v1(hitsToKOAIPriority, hitsToKOPlayer, isSwitchinFirstPriority, isFreeSwitch); // AI must successfully 1v1 with and without priority to be considered a good option
 
             // Check for Baton Pass; hitsToKO requirements mean mon can boost and BP without dying whether it's slower or not
@@ -2209,8 +2106,8 @@ static u32 GetBestMonIntegrated(struct Pokemon *party, int firstId, int lastId, 
                 }
 
                 // If mon can trap
-                if ((AI_CanSwitchinAbilityTrapOpponent(AI_DATA->switchinCandidate.battleMon.ability, opposingBattler)
-                    || (AI_CanSwitchinAbilityTrapOpponent(AI_DATA->abilities[opposingBattler], opposingBattler) && AI_DATA->switchinCandidate.battleMon.ability == ABILITY_TRACE))
+                if ((AI_CanSwitchinAbilityTrapOpponent(AI_DATA->abilities[battler], opposingBattler)
+                    || (AI_CanSwitchinAbilityTrapOpponent(AI_DATA->abilities[opposingBattler], opposingBattler) && AI_DATA->abilities[battler] == ABILITY_TRACE))
                     && canSwitchinWin1v1)
                     trapperId = i;
             }
@@ -2219,6 +2116,10 @@ static u32 GetBestMonIntegrated(struct Pokemon *party, int firstId, int lastId, 
 
     batonPassId = GetRandomSwitchinWithBatonPass(aliveCount, bits, firstId, lastId, i);
     AI_DATA->switchInCalc = FALSE;
+
+    FreeRestoreAiLogicData(savedAiLogicData);
+    FreeRestoreBattleMons(savedBattleMons);
+    SetBattlerAiData(battler, AI_DATA);
 
     // Different switching priorities depending on switching mid battle vs switching after a KO or slow switch
     if (isFreeSwitch)
@@ -2266,6 +2167,157 @@ static u32 GetNextMonInParty(struct Pokemon *party, int firstId, int lastId, u32
         }
         return i;
     }
+    return PARTY_SIZE;
+}
+
+static u32 GetSwitchinCandidate(u32 switchinCategory, u32 battler, int firstId, int lastId, enum SwitchType switchType)
+{
+    if (switchinCategory == 0)
+        return PARTY_SIZE;
+
+    // Pick last eligible mon in party order
+    for (s32 monIndex = (lastId-1); monIndex >= firstId; monIndex--)
+    {
+        if (switchinCategory & (1 << monIndex))
+            return monIndex;
+    }
+
+    return PARTY_SIZE;
+}
+
+static u32 GetValidSwitchinCandidate(u32 validMonIds, u32 battler, u32 firstId, u32 lastId, enum SwitchType switchType)
+{
+    if (validMonIds == 0)
+        return PARTY_SIZE;
+
+    // Pick last valid mon in party order
+    for (s32 monIndex = (lastId-1); monIndex > firstId; monIndex--)
+    {
+        if (validMonIds & (1 << monIndex))
+            return monIndex;
+    }
+
+    return PARTY_SIZE;
+}
+
+static u32 GetBestMonVanilla(struct Pokemon *party, int firstId, int lastId, u32 battler, u32 opposingBattler, u32 battlerIn1, u32 battlerIn2, enum SwitchType switchType)
+{
+    s32 i, j, aceMonCount = 0;
+    u32 validMonIds = 0, batonPassIds = 0, typeMatchupIds = 0, bestDamageId = PARTY_SIZE, aceMonId = PARTY_SIZE;
+    u32 bestResist = UQ_4_12(2.0), typeMatchup, bestDamage = 0;
+
+    // Save existing battler data
+    struct AiLogicData *savedAiLogicData = AllocSaveAiLogicData();
+    struct BattlePokemon *savedBattleMons = AllocSaveBattleMons();
+
+    // Get invalid slots ids.
+    for (i = firstId; i < lastId; i++)
+    {
+        if (!IsValidForBattle(&party[i])
+            || gBattlerPartyIndexes[battlerIn1] == i
+            || gBattlerPartyIndexes[battlerIn2] == i
+            || i == gBattleStruct->monToSwitchIntoId[battlerIn1]
+            || i == gBattleStruct->monToSwitchIntoId[battlerIn2])
+        {
+            continue;
+        }
+        else if (IsAceMon(battler, i)) // Save Ace Pokemon for last.
+        {
+            aceMonId = i;
+            aceMonCount++;
+        }
+        else
+        {
+            validMonIds |= (1u << i);
+        }
+    }
+
+    // Iterate through mons
+    for (i = firstId; i < lastId; i++)
+    {
+        // Check mon validity
+        if (!IsValidForBattle(&party[i])
+            || gBattlerPartyIndexes[battlerIn1] == i
+            || gBattlerPartyIndexes[battlerIn2] == i
+            || i == gBattleStruct->monToSwitchIntoId[battlerIn1]
+            || i == gBattleStruct->monToSwitchIntoId[battlerIn2])
+        {
+            continue;
+        }
+        // Save Ace Pokemon for last
+        else if (IsAceMon(battler, i))
+        {
+            aceMonId = i;
+            aceMonCount++;
+            continue;
+        }
+        else
+        {
+            validMonIds |= (1u << i);
+        }
+        InitializeSwitchinCandidate(battler, &party[i]);
+
+        // While not really invalid per se, not really wise to switch into this mon
+        if (AI_DATA->abilities[battler] == ABILITY_TRUANT && IsTruantMonVulnerable(battler, opposingBattler))
+            continue;
+
+        typeMatchup = GetBattlerTypeMatchup(opposingBattler, battler);
+
+        for (j = 0; j < MAX_MON_MOVES; j++)
+        {
+            // Check that move has PP remaining before running calcs
+            if (gBattleMons[battler].pp[j] < 1)
+                continue;
+
+            u32 aiMove = gBattleMons[battler].moves[j];
+
+            // Baton Pass
+            if (gMovesInfo[aiMove].effect == EFFECT_BATON_PASS)
+            {
+                batonPassIds |= (1u << i);
+            }
+
+            // Type Matchup
+            if (typeMatchup < bestResist && AI_DATA->effectiveness[battler][opposingBattler][j] >= UQ_4_12(2.0))
+            {
+                bestResist = typeMatchup;
+                typeMatchupIds |= (1u << i);
+            }
+
+            // Best damage
+            if (aiMove != MOVE_NONE && gMovesInfo[aiMove].category != DAMAGE_CATEGORY_STATUS)
+            {
+                u32 aiDmg = AI_GetDamage(battler, opposingBattler, j, AI_ATTACKING_IN_SWITCHIN_CALC, AI_DATA);
+                if (aiDmg > bestDamage)
+                {
+                    bestDamage = aiDmg;
+                    bestDamageId = i;
+                }
+            }
+        }
+    }
+
+    // Restore battler data
+    FreeRestoreAiLogicData(savedAiLogicData);
+    FreeRestoreBattleMons(savedBattleMons);
+    SetBattlerAiData(battler, AI_DATA);
+
+    // Baton Pass > Type Matchup > Best Damage
+    if (batonPassIds != 0)                  return GetSwitchinCandidate(batonPassIds, battler, firstId, lastId, switchType);
+    else if (typeMatchupIds != 0)           return GetSwitchinCandidate(typeMatchupIds, battler, firstId, lastId, switchType);
+    else if (bestDamageId != PARTY_SIZE)    return bestDamageId;
+
+    // Not required to switch here and no good candidates, bail
+    if (switchType == SWITCH_MID_BATTLE)
+        return PARTY_SIZE;
+
+    // Fallback
+    if (validMonIds != 0)
+        return GetValidSwitchinCandidate(validMonIds, battler, firstId, lastId, switchType);
+
+    if (aceMonId != PARTY_SIZE && CountUsablePartyMons(battler) <= aceMonCount)
+        return aceMonId;
+
     return PARTY_SIZE;
 }
 
@@ -2321,49 +2373,8 @@ u32 GetMostSuitableMonToSwitchInto(u32 battler, enum SwitchType switchType)
     // This all handled by the GetBestMonIntegrated function if the AI_FLAG_SMART_MON_CHOICES flag is set
     else
     {
-        s32 i, aliveCount = 0, aceMonCount = 0;
-        u32 invalidMons = 0, aceMonId = PARTY_SIZE;
-        // Get invalid slots ids.
-        for (i = firstId; i < lastId; i++)
-        {
-            if (!IsValidForBattle(&party[i])
-                || gBattlerPartyIndexes[battlerIn1] == i
-                || gBattlerPartyIndexes[battlerIn2] == i
-                || i == gBattleStruct->monToSwitchIntoId[battlerIn1]
-                || i == gBattleStruct->monToSwitchIntoId[battlerIn2]
-                || (GetMonAbility(&party[i]) == ABILITY_TRUANT && IsTruantMonVulnerable(battler, opposingBattler))) // While not really invalid per se, not really wise to switch into this mon.
-            {
-                invalidMons |= 1u << i;
-            }
-            else if (IsAceMon(battler, i)) // Save Ace Pokemon for last.
-            {
-                aceMonId = i;
-                aceMonCount++;
-                invalidMons |= 1u << i;
-            }
-            else
-            {
-                aliveCount++;
-            }
-        }
-        bestMonId = GetBestMonBatonPass(party, firstId, lastId, invalidMons, aliveCount, battler, opposingBattler);
-        if (bestMonId != PARTY_SIZE)
-            return bestMonId;
-
-        bestMonId = GetBestMonTypeMatchup(party, firstId, lastId, invalidMons, battler, opposingBattler);
-        if (bestMonId != PARTY_SIZE)
-            return bestMonId;
-
-        bestMonId = GetBestMonDmg(party, firstId, lastId, invalidMons, battler, opposingBattler);
-        if (bestMonId != PARTY_SIZE)
-            return bestMonId;
-
-        // If ace mon is the last available Pokemon and U-Turn/Volt Switch or Eject Pack/Button was used - switch to the mon.
-        if (aceMonId != PARTY_SIZE && CountUsablePartyMons(battler) <= aceMonCount
-        && (IsSwitchOutEffect(gMovesInfo[gCurrentMove].effect) || AI_DATA->ejectButtonSwitch || AI_DATA->ejectPackSwitch))
-            return aceMonId;
-
-        return PARTY_SIZE;
+        bestMonId = GetBestMonVanilla(party, firstId, lastId, battler, opposingBattler, battlerIn1, battlerIn2, switchType);
+        return bestMonId;
     }
 }
 

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -62,16 +62,6 @@ bool32 AI_IsSlower(u32 battlerAi, u32 battlerDef, u32 aiMove, u32 playerMove, en
     return (AI_WhoStrikesFirst(battlerAi, battlerDef, aiMove, playerMove, considerPriority) == AI_IS_SLOWER);
 }
 
-bool32 AI_IsPartyMonFaster(u32 battlerAi, u32 battlerDef, struct BattlePokemon switchinCandidate, u32 aiMove, u32 playerMove, enum ConsiderPriority considerPriority)
-{
-    return (AI_WhoStrikesFirstPartyMon(battlerAi, battlerDef, switchinCandidate, aiMove, playerMove, considerPriority) == AI_IS_FASTER);
-}
-
-bool32 AI_IsPartyMonSlower(u32 battlerAi, u32 battlerDef, struct BattlePokemon switchinCandidate, u32 aiMove, u32 playerMove, enum ConsiderPriority considerPriority)
-{
-    return (AI_WhoStrikesFirstPartyMon(battlerAi, battlerDef, switchinCandidate, aiMove, playerMove, considerPriority) == AI_IS_SLOWER);
-}
-
 u32 GetAIChosenMove(u32 battlerId)
 {
     return (gBattleMons[battlerId].moves[gBattleStruct->aiMoveOrAction[battlerId]]);
@@ -3944,9 +3934,24 @@ void FreeRestoreBattleMons(struct BattlePokemon *savedBattleMons)
     Free(savedBattleMons);
 }
 
-u32 AI_GetSwitchinWeather(struct BattlePokemon battleMon)
+#define SIZE_G_AI_LOGIC_DATA (sizeof(struct AiLogicData))
+
+struct AiLogicData *AllocSaveAiLogicData(void)
 {
-    u32 ability = battleMon.ability;
+    struct AiLogicData *savedAiLogicData = Alloc(SIZE_G_AI_LOGIC_DATA);
+    memcpy(savedAiLogicData, AI_DATA, SIZE_G_AI_LOGIC_DATA);
+    return savedAiLogicData;
+}
+
+void FreeRestoreAiLogicData(struct AiLogicData *savedAiLogicData)
+{
+    memcpy(AI_DATA, savedAiLogicData, SIZE_G_AI_LOGIC_DATA);
+    Free(savedAiLogicData);
+}
+
+u32 AI_GetSwitchinWeather(u32 battler)
+{
+    u32 ability = gBattleMons[battler].ability;
     // Forced weather behaviour
     if (!AI_WeatherHasEffect(AI_DATA))
         return B_WEATHER_NONE;
@@ -3971,54 +3976,7 @@ u32 AI_GetSwitchinWeather(struct BattlePokemon battleMon)
     }    
 }
 
-// party logic
-s32 AI_CalcPartyMonDamage(u32 move, u32 battlerAtk, u32 battlerDef, struct BattlePokemon switchinCandidate, enum DamageCalcContext calcContext)
-{
-    struct SimulatedDamage dmg;
-    uq4_12_t effectiveness;
-    struct BattlePokemon *savedBattleMons = AllocSaveBattleMons();
-
-    if (calcContext == AI_ATTACKING_IN_SWITCHIN_CALC)
-    {
-        gBattleMons[battlerAtk] = switchinCandidate;
-        AI_THINKING_STRUCT->saved[battlerDef].saved = TRUE;
-        SetBattlerAiData(battlerAtk, AI_DATA); // set known opposing battler data
-        AI_THINKING_STRUCT->saved[battlerDef].saved = FALSE;
-    }
-    else if (calcContext == AI_DEFENDING_NORMAL)
-    {
-        gBattleMons[battlerDef] = switchinCandidate;
-        AI_THINKING_STRUCT->saved[battlerAtk].saved = TRUE;
-        SetBattlerAiData(battlerDef, AI_DATA); // set known opposing battler data
-        AI_THINKING_STRUCT->saved[battlerAtk].saved = FALSE;
-    }
-
-    dmg = AI_CalcDamage(move, battlerAtk, battlerDef, &effectiveness, FALSE, AI_GetSwitchinWeather(switchinCandidate));
-
-    // restores original gBattleMon struct
-    FreeRestoreBattleMons(savedBattleMons);
-
-    if (calcContext == AI_ATTACKING_IN_SWITCHIN_CALC)
-        SetBattlerAiData(battlerAtk, AI_DATA);
-
-    else if (calcContext == AI_DEFENDING_NORMAL)
-        SetBattlerAiData(battlerDef, AI_DATA);
-
-    return dmg.median;
-}
-
-u32 AI_WhoStrikesFirstPartyMon(u32 battlerAtk, u32 battlerDef, struct BattlePokemon switchinCandidate, u32 aiMoveConsidered, u32 playerMoveConsidered, enum ConsiderPriority considerPriority)
-{
-    struct BattlePokemon *savedBattleMons = AllocSaveBattleMons();
-    gBattleMons[battlerAtk] = switchinCandidate;
-
-    SetBattlerAiData(battlerAtk, AI_DATA);
-    u32 aiWhoStrikesFirst = AI_WhoStrikesFirst(battlerAtk, battlerDef, aiMoveConsidered, playerMoveConsidered, considerPriority);
-    FreeRestoreBattleMons(savedBattleMons);
-    SetBattlerAiData(battlerAtk, AI_DATA);
-
-    return aiWhoStrikesFirst;
-}
+// TODO - pull getswitchinfieldstatus/setbattlerfieldstatusforswtichin from upstream?
 
 s32 CountUsablePartyMons(u32 battlerId)
 {


### PR DESCRIPTION
## Description
This is a massive refactor courtesy of Pawkkie to the AI switch logic system, better leveraging battler data structures to enable more complex and more efficient calculations of switch-in cases. Two PRs are merged here from upstream - 
https://github.com/rh-hideout/pokeemerald-expansion/pull/8546
https://github.com/rh-hideout/pokeemerald-expansion/pull/8556

## **People who collaborated with me in this PR**
@Pawkkie for the upstream code, @MaximeGr00 for encouragement

## Feature(s) this PR does NOT handle:
- This is the required groundwork to fix issue #102 fully
- Upstream referenced SetBattlerFieldStatusForSwitchin(), which would enable better terrain/field state handling outside of weather on switch-ins. Most battles in this hack do not have a terrain setter in the back, so it's low priority, but that should prob be merged in from upstream as well.
- Currently there are 146 total failing tests, 12 of which tagged with AI_FLAG_SMART_SWITCHING, and 8 tagged with AI_FLAG_SMART_MON_CHOICES. These tests and the rest of ai_switching.c and ai_calc_best_move_score.c should be fixed up once issue 102 is finalized.

## Things to note in the release changelog:
- AI engine overhauled for better switch-in calculation performance and complexity

## **Discord contact info**
ghostyboyy97
