### PR TITLE
Hard mode eggs and restricted summoning

### DIFF
--- a/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
+++ b/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
@@ -379,216 +379,290 @@ FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive::
 # 193 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	faceplayer
 # 194 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto_if_set FLAG_STARTER_EGG, FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_2
+# 200 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_6
+# 206 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox EggManIntro
-# 196 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_0, ITEM_RED_SHARD
-# 197 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_1, ITEM_BLUE_SHARD
-# 198 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_2, ITEM_GREEN_SHARD
-# 199 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_3, MULTI_B_PRESSED
-# 202 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	dynmultistack 0, 0, FALSE, 6, FALSE, 3, DYN_MULTICHOICE_CB_NONE
-# 204 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	compare VAR_RESULT, MULTI_B_PRESSED
-	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_2
-FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_1:
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_5:
 # 209 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_1, ITEM_RED_SHARD
+# 210 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_2, ITEM_BLUE_SHARD
+# 211 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_3, ITEM_GREEN_SHARD
+# 212 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	dynmultipush FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_4, MULTI_B_PRESSED
+# 215 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	dynmultistack 0, 0, FALSE, 6, FALSE, 3, DYN_MULTICHOICE_CB_NONE
+# 217 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_RESULT, MULTI_B_PRESSED
+	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_10
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_9:
+# 222 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	compare VAR_RESULT, ITEM_RED_SHARD
-	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_5
-FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_4:
-# 213 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_13
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_12:
+# 226 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	compare VAR_RESULT, ITEM_BLUE_SHARD
-	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_8
-FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_7:
-# 218 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_16
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_15:
+# 230 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	compare VAR_RESULT, ITEM_GREEN_SHARD
-	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_11
-FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_10:
-# 223 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto_if_eq FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_18
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_1:
+# 235 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
 
 FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_2:
-# 206 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	goto FallarborTown_MoveRelearnersHouse_EventScript_EggManNo
+# 196 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_0
 	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_1
 
-FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_5:
-# 211 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_6:
+# 202 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox EggManIntroHard
+	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_5
+
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_10:
+# 219 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto FallarborTown_MoveRelearnersHouse_EventScript_EggManNo
+	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_9
+
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_13:
+# 224 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg
-	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_4
+	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_12
 
-FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_8:
-# 215 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_16:
+# 228 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg
-# 216 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	msgbox FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_4
-	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_7
+	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_15
 
-FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_11:
-# 220 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_18:
+# 232 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg
-# 221 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	msgbox FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_4
-	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_10
+	goto FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_1
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg::
-# 229 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	checkitem ITEM_RED_SHARD
-# 230 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	goto_if_eq VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithRedShard
-# 231 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 241 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_lt FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_2
+FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_1:
+# 246 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	getpartysize
-# 232 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 247 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	goto_if_eq VAR_RESULT, PARTY_SIZE, FallarborTown_MoveRelearnersHouse_EventScript_NoRoomForEgg
-# 233 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 248 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_0
-# 234 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 249 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	playfanfare MUS_OBTAIN_ITEM
-# 235 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 250 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	message FallarborTown_MoveRelearnersHouse_Text_ReceivedTheEgg
-# 236 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 251 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	waitfanfare
-# 237 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 252 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	giveegg SPECIES_CHARMANDER
-# 238 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 253 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_5
+# 260 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	removeitem ITEM_RED_SHARD
-# 239 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	msgbox FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_4
-# 240 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 261 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_2
+FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_4:
+# 263 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
+
+FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_2:
+# 243 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	checkitem ITEM_RED_SHARD
+# 244 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto_if_eq VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithRedShard
+	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_1
+
+FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_5:
+# 255 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_1
+# 256 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	setflag FLAG_STARTER_EGG
+	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_4
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg::
-# 245 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	checkitem ITEM_BLUE_SHARD
-# 246 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	goto_if_eq VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithBlueShard
-# 247 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 268 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_lt FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_2
+FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_1:
+# 273 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	getpartysize
-# 248 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 274 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	goto_if_eq VAR_RESULT, PARTY_SIZE, FallarborTown_MoveRelearnersHouse_EventScript_NoRoomForEgg
-# 249 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 275 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_0
-# 250 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 276 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	playfanfare MUS_OBTAIN_ITEM
-# 251 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 277 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	message FallarborTown_MoveRelearnersHouse_Text_ReceivedTheEgg
-# 252 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 278 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	waitfanfare
-# 253 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 279 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	giveegg SPECIES_SQUIRTLE
-# 254 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 280 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_5
+# 287 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	removeitem ITEM_BLUE_SHARD
-# 255 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	msgbox FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_4
-# 256 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 288 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_2
+FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_4:
+# 290 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
+
+FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_2:
+# 270 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	checkitem ITEM_BLUE_SHARD
+# 271 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto_if_eq VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithBlueShard
+	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_1
+
+FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_5:
+# 282 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_1
+# 283 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	setflag FLAG_STARTER_EGG
+	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg_4
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg::
-# 261 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	checkitem ITEM_GREEN_SHARD
-# 262 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	goto_if_eq VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithGreenShard
-# 263 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 295 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_lt FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_2
+FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_1:
+# 300 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	getpartysize
-# 264 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 301 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	goto_if_eq VAR_RESULT, PARTY_SIZE, FallarborTown_MoveRelearnersHouse_EventScript_NoRoomForEgg
-# 265 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 302 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_0
-# 266 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 303 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	playfanfare MUS_OBTAIN_ITEM
-# 267 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 304 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	message FallarborTown_MoveRelearnersHouse_Text_ReceivedTheEgg
-# 268 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 305 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	waitfanfare
-# 269 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 306 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	giveegg SPECIES_BULBASAUR
-# 270 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 307 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_5
+# 314 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	removeitem ITEM_GREEN_SHARD
-# 271 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	msgbox FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_4
-# 272 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 315 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_2
+FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_4:
+# 317 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
 
+FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_2:
+# 297 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	checkitem ITEM_GREEN_SHARD
+# 298 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	goto_if_eq VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithGreenShard
+	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_1
+
+FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_5:
+# 309 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	msgbox FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_1
+# 310 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	setflag FLAG_STARTER_EGG
+	goto FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg_4
+
 
 FallarborTown_MoveRelearnersHouse_EventScript_EggManNo::
-# 277 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 322 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_EventScript_EggManNo_Text_0
-# 278 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 323 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithRedShard::
-# 283 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 328 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_Text_ComeBackWithRedShard, MSGBOX_DEFAULT
-# 284 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 329 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithBlueShard::
-# 289 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 334 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_Text_ComeBackWithBlueShard, MSGBOX_DEFAULT
-# 290 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 335 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithGreenShard::
-# 295 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 340 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_Text_ComeBackWithGreenShard, MSGBOX_DEFAULT
-# 296 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 341 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_NoRoomForEgg::
-# 301 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 346 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	msgbox FallarborTown_MoveRelearnersHouse_Text_NoRoomForThisEgg, MSGBOX_DEFAULT
-# 302 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 347 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	release
 	end
 
 
 FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_0:
 # 196 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	.string "{COLOR RED}{SHADOW LIGHT_RED}Fire$"
+	.string "Another?!\nYour greed knows no bounds.$"
 
 FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_1:
-# 197 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	.string "{COLOR BLUE}{SHADOW LIGHT_BLUE}Water$"
+# 209 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	.string "{COLOR RED}{SHADOW LIGHT_RED}Fire$"
 
 FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_2:
-# 198 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	.string "{COLOR GREEN}{SHADOW LIGHT_GREEN}Grass$"
+# 210 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	.string "{COLOR BLUE}{SHADOW LIGHT_BLUE}Water$"
 
 FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_3:
-# 199 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	.string "Cancel$"
+# 211 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	.string "{COLOR GREEN}{SHADOW LIGHT_GREEN}Grass$"
 
 FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive_Text_4:
-# 216 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
-	.string "Come back if you have more shards!$"
+# 212 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	.string "Cancel$"
 
 FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_0:
-# 233 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 248 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "A wise choice. Here you go.$"
 
+FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_1:
+# 255 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	.string "I hope you'll do great things!$"
+
+FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg_Text_2:
+# 261 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	.string "Come back if you have more shards!$"
+
 FallarborTown_MoveRelearnersHouse_EventScript_EggManNo_Text_0:
-# 277 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 322 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "I see. Come back when you\nwant a starter egg.$"
 
 EggManIntro::
-# 309 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 354 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "Hello, I am a shard collector. If you\n"
 	.string "give me a Red Shard, I can give you an\l"
 	.string "Egg for a Fire-type starter Pokémon.\p"
@@ -597,26 +671,36 @@ EggManIntro::
 	.string "starters.\p"
 	.string "Which type of Egg do you want?$"
 
+EggManIntroHard::
+# 365 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+	.string "Hello, trainer. Wow, you have\n"
+	.string "sharp eyes, full of passion!\p"
+	.string "I'll tell you what, I have three\n"
+	.string "eggs here, for each starter type.\n"
+	.string "I'm always looking for promising\l"
+	.string "trainers to take them on adventures.\p"
+	.string "So, which type of Egg do you want?$"
+
 FallarborTown_MoveRelearnersHouse_Text_ComeBackWithRedShard::
-# 320 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 375 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "It doesn't look like you have a Red\n"
 	.string "Shard. Come back when you do.$"
 
 FallarborTown_MoveRelearnersHouse_Text_ComeBackWithBlueShard::
-# 325 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 380 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "It doesn't look like you have a Blue\n"
 	.string "Shard. Come back when you do.$"
 
 FallarborTown_MoveRelearnersHouse_Text_ComeBackWithGreenShard::
-# 330 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 385 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "It doesn't look like you have a Green\n"
 	.string "Shard. Come back when you do.$"
 
 FallarborTown_MoveRelearnersHouse_Text_NoRoomForThisEgg::
-# 335 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 390 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "Oh? You've too many Pokémon.\n"
 	.string "There's no room for this Egg.$"
 
 FallarborTown_MoveRelearnersHouse_Text_ReceivedTheEgg::
-# 340 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
+# 395 "data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory"
 	.string "{PLAYER} received the Egg.$"

--- a/data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory
+++ b/data/maps/FallarborTown_MoveRelearnersHouse/scripts.pory
@@ -191,34 +191,46 @@ FallarborTown_MoveRelearnersHouse_Text_CantTeachEgg:
 script FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive {
 	lock
 	faceplayer
-	msgbox(EggManIntro)
-
-	dynmultipush("{COLOR RED}{SHADOW LIGHT_RED}Fire", ITEM_RED_SHARD)
-	dynmultipush("{COLOR BLUE}{SHADOW LIGHT_BLUE}Water", ITEM_BLUE_SHARD)
-	dynmultipush("{COLOR GREEN}{SHADOW LIGHT_GREEN}Grass", ITEM_GREEN_SHARD)
-    dynmultipush("Cancel", MULTI_B_PRESSED)
-
-    // // setting initial selected to a non-existant ID will always have it point to the first option
-	dynmultistack(0, 0, FALSE, 6, FALSE, 3, DYN_MULTICHOICE_CB_NONE)
-
-    if (var(VAR_RESULT) == MULTI_B_PRESSED) 
+	if(flag(FLAG_STARTER_EGG))
 	{
-		goto(FallarborTown_MoveRelearnersHouse_EventScript_EggManNo)
+		msgbox("Another?!\nYour greed knows no bounds.")
 	}
+	else
+	{
+		if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+		{
+			msgbox(EggManIntroHard)
+		}
+		else
+		{
+			msgbox(EggManIntro)
+		}
 
-	if (var(VAR_RESULT) == ITEM_RED_SHARD)
-	{
-		goto(FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg)
-	}
-	if (var(VAR_RESULT) == ITEM_BLUE_SHARD)
-	{
-		goto(FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg)
-		msgbox("Come back if you have more shards!")
-	}
-	if (var(VAR_RESULT) == ITEM_GREEN_SHARD)
-	{
-		goto(FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg)
-		msgbox("Come back if you have more shards!")
+		dynmultipush("{COLOR RED}{SHADOW LIGHT_RED}Fire", ITEM_RED_SHARD)
+		dynmultipush("{COLOR BLUE}{SHADOW LIGHT_BLUE}Water", ITEM_BLUE_SHARD)
+		dynmultipush("{COLOR GREEN}{SHADOW LIGHT_GREEN}Grass", ITEM_GREEN_SHARD)
+		dynmultipush("Cancel", MULTI_B_PRESSED)
+
+		// // setting initial selected to a non-existant ID will always have it point to the first option
+		dynmultistack(0, 0, FALSE, 6, FALSE, 3, DYN_MULTICHOICE_CB_NONE)
+
+		if (var(VAR_RESULT) == MULTI_B_PRESSED) 
+		{
+			goto(FallarborTown_MoveRelearnersHouse_EventScript_EggManNo)
+		}
+
+		if (var(VAR_RESULT) == ITEM_RED_SHARD)
+		{
+			goto(FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg)
+		}
+		if (var(VAR_RESULT) == ITEM_BLUE_SHARD)
+		{
+			goto(FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg)
+		}
+		if (var(VAR_RESULT) == ITEM_GREEN_SHARD)
+		{
+			goto(FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg)
+		}
 	}
 	release
 	end
@@ -226,8 +238,11 @@ script FallarborTown_MoveRelearnersHouse_EventScript_StarterEggGive {
 }
 
 script FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg {
-	checkitem(ITEM_RED_SHARD)
-	goto_if_eq(VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithRedShard)
+	if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) < GAME_SETTING_DIFFICULTY_HARD_MODE)
+	{
+		checkitem(ITEM_RED_SHARD)
+		goto_if_eq(VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithRedShard)
+	}
 	getpartysize
 	goto_if_eq(VAR_RESULT, PARTY_SIZE, FallarborTown_MoveRelearnersHouse_EventScript_NoRoomForEgg)
 	msgbox("A wise choice. Here you go.")
@@ -235,15 +250,26 @@ script FallarborTown_MoveRelearnersHouse_EventScript_GiveFireEgg {
 	message(FallarborTown_MoveRelearnersHouse_Text_ReceivedTheEgg)
 	waitfanfare
 	giveegg(SPECIES_CHARMANDER)
-	removeitem(ITEM_RED_SHARD)
-	msgbox("Come back if you have more shards!")
+	if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+	{
+		msgbox("I hope you'll do great things!")
+		setflag(FLAG_STARTER_EGG)
+	}
+	else
+	{
+		removeitem(ITEM_RED_SHARD)
+		msgbox("Come back if you have more shards!")
+	}
 	release
 	end
 }
 
 script FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg {
-	checkitem(ITEM_BLUE_SHARD)
-	goto_if_eq(VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithBlueShard)
+	if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) < GAME_SETTING_DIFFICULTY_HARD_MODE)
+	{
+		checkitem(ITEM_BLUE_SHARD)
+		goto_if_eq(VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithBlueShard)
+	}
 	getpartysize
 	goto_if_eq(VAR_RESULT, PARTY_SIZE, FallarborTown_MoveRelearnersHouse_EventScript_NoRoomForEgg)
 	msgbox("A wise choice. Here you go.")
@@ -251,15 +277,26 @@ script FallarborTown_MoveRelearnersHouse_EventScript_GiveWaterEgg {
 	message(FallarborTown_MoveRelearnersHouse_Text_ReceivedTheEgg)
 	waitfanfare
 	giveegg(SPECIES_SQUIRTLE)
-	removeitem(ITEM_BLUE_SHARD)
-	msgbox("Come back if you have more shards!")
+	if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+	{
+		msgbox("I hope you'll do great things!")
+		setflag(FLAG_STARTER_EGG)
+	}
+	else
+	{
+		removeitem(ITEM_BLUE_SHARD)
+		msgbox("Come back if you have more shards!")
+	}
 	release
 	end
 }
 
 script FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg {
-	checkitem(ITEM_GREEN_SHARD)
-	goto_if_eq(VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithGreenShard)
+	if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) < GAME_SETTING_DIFFICULTY_HARD_MODE)
+	{
+		checkitem(ITEM_GREEN_SHARD)
+		goto_if_eq(VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithGreenShard)
+	}
 	getpartysize
 	goto_if_eq(VAR_RESULT, PARTY_SIZE, FallarborTown_MoveRelearnersHouse_EventScript_NoRoomForEgg)
 	msgbox("A wise choice. Here you go.")
@@ -267,8 +304,16 @@ script FallarborTown_MoveRelearnersHouse_EventScript_GiveGrassEgg {
 	message(FallarborTown_MoveRelearnersHouse_Text_ReceivedTheEgg)
 	waitfanfare
 	giveegg(SPECIES_BULBASAUR)
-	removeitem(ITEM_GREEN_SHARD)
-	msgbox("Come back if you have more shards!")
+	if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+	{
+		msgbox("I hope you'll do great things!")
+		setflag(FLAG_STARTER_EGG)
+	}
+	else
+	{
+		removeitem(ITEM_GREEN_SHARD)
+		msgbox("Come back if you have more shards!")
+	}
 	release
 	end
 }
@@ -315,6 +360,16 @@ text EggManIntro {
 	"starters.\p"
 	"Which type of Egg do you want?"
 	
+}
+
+text EggManIntroHard {
+	"Hello, trainer. Wow, you have\n"
+	"sharp eyes, full of passion!\p"
+	"I'll tell you what, I have three\n"
+	"eggs here, for each starter type.\n"
+	"I'm always looking for promising\l"
+	"trainers to take them on adventures.\p"
+	"So, which type of Egg do you want?"
 }
 
 text FallarborTown_MoveRelearnersHouse_Text_ComeBackWithRedShard {

--- a/data/maps/LavaridgeTown/scripts.inc
+++ b/data/maps/LavaridgeTown/scripts.inc
@@ -805,69 +805,123 @@ LavaridgeTown_EventScript_EggWoman::
 # 405 "data/maps/LavaridgeTown/scripts.pory"
 	faceplayer
 # 406 "data/maps/LavaridgeTown/scripts.pory"
-	msgbox LavaridgeTown_EggWomanIntro, MSGBOX_YESNO
-# 408 "data/maps/LavaridgeTown/scripts.pory"
-	compare VAR_RESULT, NO
-	goto_if_eq LavaridgeTown_EventScript_EggWoman_2
-LavaridgeTown_EventScript_EggWoman_1:
-# 413 "data/maps/LavaridgeTown/scripts.pory"
-	checkitem ITEM_YELLOW_SHARD
-# 414 "data/maps/LavaridgeTown/scripts.pory"
-	goto_if_eq VAR_RESULT, FALSE, LavaridgeTown_EventScript_ComeBackWithYellowShard
-# 415 "data/maps/LavaridgeTown/scripts.pory"
-	getpartysize
-# 416 "data/maps/LavaridgeTown/scripts.pory"
-	goto_if_eq VAR_RESULT, PARTY_SIZE, LavaridgeTown_EventScript_NoRoomForEgg
-# 417 "data/maps/LavaridgeTown/scripts.pory"
-	msgbox LavaridgeTown_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT
-# 418 "data/maps/LavaridgeTown/scripts.pory"
-	playfanfare MUS_OBTAIN_ITEM
-# 419 "data/maps/LavaridgeTown/scripts.pory"
-	message LavaridgeTown_Text_ReceivedTheEgg
-# 420 "data/maps/LavaridgeTown/scripts.pory"
-	waitfanfare
-# 421 "data/maps/LavaridgeTown/scripts.pory"
-	giveegg SPECIES_KLAWF
+	goto_if_set FLAG_LAVARIDGE_EGG, LavaridgeTown_EventScript_EggWoman_2
+# 412 "data/maps/LavaridgeTown/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge LavaridgeTown_EventScript_EggWoman_6
 # 422 "data/maps/LavaridgeTown/scripts.pory"
-	removeitem ITEM_YELLOW_SHARD
+	msgbox LavaridgeTown_EggWomanIntro, MSGBOX_YESNO
 # 423 "data/maps/LavaridgeTown/scripts.pory"
+	compare VAR_RESULT, NO
+	goto_if_eq LavaridgeTown_EventScript_EggWoman_15
+LavaridgeTown_EventScript_EggWoman_14:
+# 427 "data/maps/LavaridgeTown/scripts.pory"
+	checkitem ITEM_YELLOW_SHARD
+# 428 "data/maps/LavaridgeTown/scripts.pory"
+	goto_if_eq VAR_RESULT, FALSE, LavaridgeTown_EventScript_ComeBackWithYellowShard
+LavaridgeTown_EventScript_EggWoman_5:
+# 430 "data/maps/LavaridgeTown/scripts.pory"
+	getpartysize
+# 431 "data/maps/LavaridgeTown/scripts.pory"
+	goto_if_eq VAR_RESULT, PARTY_SIZE, LavaridgeTown_EventScript_NoRoomForEgg
+# 432 "data/maps/LavaridgeTown/scripts.pory"
+	msgbox LavaridgeTown_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT
+# 433 "data/maps/LavaridgeTown/scripts.pory"
+	playfanfare MUS_OBTAIN_ITEM
+# 434 "data/maps/LavaridgeTown/scripts.pory"
+	message LavaridgeTown_Text_ReceivedTheEgg
+# 435 "data/maps/LavaridgeTown/scripts.pory"
+	waitfanfare
+# 436 "data/maps/LavaridgeTown/scripts.pory"
+	giveegg SPECIES_KLAWF
+# 437 "data/maps/LavaridgeTown/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge LavaridgeTown_EventScript_EggWoman_9
+# 444 "data/maps/LavaridgeTown/scripts.pory"
+	removeitem ITEM_YELLOW_SHARD
+# 445 "data/maps/LavaridgeTown/scripts.pory"
 	msgbox LavaridgeTown_ComeBackWithMore, MSGBOX_DEFAULT
-# 424 "data/maps/LavaridgeTown/scripts.pory"
+LavaridgeTown_EventScript_EggWoman_1:
+# 448 "data/maps/LavaridgeTown/scripts.pory"
 	release
 	end
 
 LavaridgeTown_EventScript_EggWoman_2:
-# 410 "data/maps/LavaridgeTown/scripts.pory"
-	goto LavaridgeTown_EventScript_EggWomanManNo
+# 408 "data/maps/LavaridgeTown/scripts.pory"
+	msgbox LavaridgeTown_EventScript_EggWoman_Text_0
 	goto LavaridgeTown_EventScript_EggWoman_1
+
+LavaridgeTown_EventScript_EggWoman_6:
+# 414 "data/maps/LavaridgeTown/scripts.pory"
+	msgbox LavaridgeTown_EggWomanIntroHard, MSGBOX_YESNO
+# 415 "data/maps/LavaridgeTown/scripts.pory"
+	compare VAR_RESULT, NO
+	goto_if_eq LavaridgeTown_EventScript_EggWoman_12
+	goto LavaridgeTown_EventScript_EggWoman_5
+
+LavaridgeTown_EventScript_EggWoman_9:
+# 439 "data/maps/LavaridgeTown/scripts.pory"
+	msgbox LavaridgeTown_EventScript_EggWoman_Text_1
+# 440 "data/maps/LavaridgeTown/scripts.pory"
+	setflag FLAG_LAVARIDGE_EGG
+	goto LavaridgeTown_EventScript_EggWoman_1
+
+LavaridgeTown_EventScript_EggWoman_12:
+# 417 "data/maps/LavaridgeTown/scripts.pory"
+	goto LavaridgeTown_EventScript_EggWomanManNo
+	goto LavaridgeTown_EventScript_EggWoman_5
+
+LavaridgeTown_EventScript_EggWoman_15:
+# 425 "data/maps/LavaridgeTown/scripts.pory"
+	goto LavaridgeTown_EventScript_EggWomanManNo
+	goto LavaridgeTown_EventScript_EggWoman_14
 
 
 LavaridgeTown_EventScript_EggWomanManNo::
-# 430 "data/maps/LavaridgeTown/scripts.pory"
+# 454 "data/maps/LavaridgeTown/scripts.pory"
 	msgbox LavaridgeTown_EggWomanDeclined, MSGBOX_DEFAULT
-# 431 "data/maps/LavaridgeTown/scripts.pory"
+# 455 "data/maps/LavaridgeTown/scripts.pory"
 	release
 	end
 
 
 LavaridgeTown_EventScript_ComeBackWithYellowShard::
-# 436 "data/maps/LavaridgeTown/scripts.pory"
+# 460 "data/maps/LavaridgeTown/scripts.pory"
 	msgbox LavaridgeTown_Text_ComeBackWithYellowShard, MSGBOX_DEFAULT
-# 437 "data/maps/LavaridgeTown/scripts.pory"
+# 461 "data/maps/LavaridgeTown/scripts.pory"
 	release
 	end
 
 
 LavaridgeTown_EventScript_NoRoomForEgg::
-# 442 "data/maps/LavaridgeTown/scripts.pory"
+# 466 "data/maps/LavaridgeTown/scripts.pory"
 	msgbox LavaridgeTown_Text_NoRoomForThisEgg, MSGBOX_DEFAULT
-# 443 "data/maps/LavaridgeTown/scripts.pory"
+# 467 "data/maps/LavaridgeTown/scripts.pory"
 	release
 	end
 
 
+LavaridgeTown_EventScript_EggWoman_Text_0:
+# 408 "data/maps/LavaridgeTown/scripts.pory"
+	.string "Keep on growing!$"
+
+LavaridgeTown_EventScript_EggWoman_Text_1:
+# 439 "data/maps/LavaridgeTown/scripts.pory"
+	.string "Take good care of it!$"
+
+LavaridgeTown_EggWomanIntroHard::
+# 471 "data/maps/LavaridgeTown/scripts.pory"
+	.string "Hello, trainer. I see you've\n"
+	.string "found your way from Fallarbor.\p"
+	.string "My old friend told me a lively\n"
+	.string "youngin would arrive shortly.\p"
+	.string "The road only gets steeper from\n"
+	.string "here, but this Egg should help.\p"
+	.string "So, do you think you can go\n"
+	.string "even further?$"
+
 LavaridgeTown_EggWomanIntro::
-# 447 "data/maps/LavaridgeTown/scripts.pory"
+# 482 "data/maps/LavaridgeTown/scripts.pory"
 	.string "Hello, trainer. I have several large\n"
 	.string "Eggs here with me.\p"
 	.string "I am currently seeking Yellow Shards,\n"
@@ -876,30 +930,30 @@ LavaridgeTown_EggWomanIntro::
 	.string "these Eggs?$"
 
 LavaridgeTown_EggWomanDeclined::
-# 456 "data/maps/LavaridgeTown/scripts.pory"
+# 491 "data/maps/LavaridgeTown/scripts.pory"
 	.string "I see. Please come back if you change\n"
 	.string "your mind.$"
 
 LavaridgeTown_Text_ComeBackWithYellowShard::
-# 462 "data/maps/LavaridgeTown/scripts.pory"
+# 497 "data/maps/LavaridgeTown/scripts.pory"
 	.string "It doesn't look like you have a\n"
 	.string "Yellow Shard. Come back when you do.$"
 
 LavaridgeTown_Text_NoRoomForThisEgg::
-# 467 "data/maps/LavaridgeTown/scripts.pory"
+# 502 "data/maps/LavaridgeTown/scripts.pory"
 	.string "Oh? You've too many Pokémon.\n"
 	.string "There's no room for this Egg…$"
 
 LavaridgeTown_Text_HopeYoullWalkPlentyWithEgg::
-# 472 "data/maps/LavaridgeTown/scripts.pory"
+# 507 "data/maps/LavaridgeTown/scripts.pory"
 	.string "Good! I hope you'll walk plenty with\n"
-	.string "this here Egg!$"
+	.string "this Egg!$"
 
 LavaridgeTown_Text_ReceivedTheEgg::
-# 477 "data/maps/LavaridgeTown/scripts.pory"
+# 512 "data/maps/LavaridgeTown/scripts.pory"
 	.string "{PLAYER} received the Egg.$"
 
 LavaridgeTown_ComeBackWithMore::
-# 481 "data/maps/LavaridgeTown/scripts.pory"
+# 516 "data/maps/LavaridgeTown/scripts.pory"
 	.string "Please come back if you have more\n"
 	.string "Yellow Shards you'd like to exchange.$"

--- a/data/maps/LavaridgeTown/scripts.pory
+++ b/data/maps/LavaridgeTown/scripts.pory
@@ -403,24 +403,48 @@ LavaridgeTown_Text_Sandygast:
 script LavaridgeTown_EventScript_EggWoman {
 	lock
 	faceplayer
-	msgbox(LavaridgeTown_EggWomanIntro, MSGBOX_YESNO)
-
-	if(var(VAR_RESULT) == NO)
+	if(flag(FLAG_LAVARIDGE_EGG))
 	{
-		goto(LavaridgeTown_EventScript_EggWomanManNo)
+		msgbox("Keep on growing!")
 	}
-
-	checkitem(ITEM_YELLOW_SHARD)
-	goto_if_eq(VAR_RESULT, FALSE, LavaridgeTown_EventScript_ComeBackWithYellowShard)
-	getpartysize
-	goto_if_eq(VAR_RESULT, PARTY_SIZE, LavaridgeTown_EventScript_NoRoomForEgg)
-	msgbox(LavaridgeTown_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT)
-	playfanfare(MUS_OBTAIN_ITEM)
-	message(LavaridgeTown_Text_ReceivedTheEgg)
-	waitfanfare
-	giveegg(SPECIES_KLAWF)
-	removeitem(ITEM_YELLOW_SHARD)
-	msgbox(LavaridgeTown_ComeBackWithMore, MSGBOX_DEFAULT)
+	else
+	{
+		if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+		{
+			msgbox(LavaridgeTown_EggWomanIntroHard, MSGBOX_YESNO)
+			if(var(VAR_RESULT) == NO)
+			{
+				goto(LavaridgeTown_EventScript_EggWomanManNo)
+			}
+		}
+		else
+		{
+			msgbox(LavaridgeTown_EggWomanIntro, MSGBOX_YESNO)
+			if(var(VAR_RESULT) == NO)
+			{
+				goto(LavaridgeTown_EventScript_EggWomanManNo)
+			}
+			checkitem(ITEM_YELLOW_SHARD)
+			goto_if_eq(VAR_RESULT, FALSE, LavaridgeTown_EventScript_ComeBackWithYellowShard)
+		}
+		getpartysize
+		goto_if_eq(VAR_RESULT, PARTY_SIZE, LavaridgeTown_EventScript_NoRoomForEgg)
+		msgbox(LavaridgeTown_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT)
+		playfanfare(MUS_OBTAIN_ITEM)
+		message(LavaridgeTown_Text_ReceivedTheEgg)
+		waitfanfare
+		giveegg(SPECIES_KLAWF)
+		if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+		{
+			msgbox("Take good care of it!")
+			setflag(FLAG_LAVARIDGE_EGG)
+		}
+		else
+		{
+			removeitem(ITEM_YELLOW_SHARD)
+			msgbox(LavaridgeTown_ComeBackWithMore, MSGBOX_DEFAULT)
+		}
+	}
 	release
 	end
 	
@@ -442,6 +466,17 @@ script LavaridgeTown_EventScript_NoRoomForEgg {
 	msgbox(LavaridgeTown_Text_NoRoomForThisEgg, MSGBOX_DEFAULT)
 	release
 	end
+}
+
+text LavaridgeTown_EggWomanIntroHard {
+	"Hello, trainer. I see you've\n"
+	"found your way from Fallarbor.\p"
+	"My old friend told me a lively\n"
+	"youngin would arrive shortly.\p"
+	"The road only gets steeper from\n"
+	"here, but this Egg should help.\p"
+	"So, do you think you can go\n"
+	"even further?"
 }
 
 text LavaridgeTown_EggWomanIntro {
@@ -471,7 +506,7 @@ text LavaridgeTown_Text_NoRoomForThisEgg {
 
 text LavaridgeTown_Text_HopeYoullWalkPlentyWithEgg {
 	"Good! I hope you'll walk plenty with\n"
-	"this here Egg!"
+	"this Egg!"
 }
 
 text LavaridgeTown_Text_ReceivedTheEgg {

--- a/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.inc
@@ -101,69 +101,112 @@ PacifidlogTown_PokemonCenter_1F_EventScript_EggMan::
 # 53 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	faceplayer
 # 54 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	msgbox PacifidlogTown_PokemonCenter_1F_PseudoManIntro, MSGBOX_YESNO
-# 56 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	compare VAR_RESULT, NO
-	goto_if_eq PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_2
-PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_1:
-# 61 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	checkitem ITEM_YELLOW_SHARD
-# 62 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	goto_if_eq VAR_RESULT, FALSE, PacifidlogTown_PokemonCenter_1F_EventScript_ComeBackWithYellowShard
-# 63 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	getpartysize
-# 64 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	goto_if_eq VAR_RESULT, PARTY_SIZE, PacifidlogTown_PokemonCenter_1F_EventScript_NoRoomForEgg
-# 65 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT
-# 66 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	playfanfare MUS_OBTAIN_ITEM
-# 67 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	message PacifidlogTown_PokemonCenter_1F_Text_ReceivedTheEgg
-# 68 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	waitfanfare
-# 69 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	giveegg SPECIES_DRATINI
+	goto_if_set FLAG_PSEUDO_EGG, PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_2
+# 60 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_6
 # 70 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	removeitem ITEM_YELLOW_SHARD
+	msgbox PacifidlogTown_PokemonCenter_1F_PseudoManIntro, MSGBOX_YESNO
 # 71 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	compare VAR_RESULT, NO
+	goto_if_eq PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_15
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_14:
+# 75 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	checkitem ITEM_YELLOW_SHARD
+# 76 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	goto_if_eq VAR_RESULT, FALSE, PacifidlogTown_PokemonCenter_1F_EventScript_ComeBackWithYellowShard
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_5:
+# 78 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	getpartysize
+# 79 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	goto_if_eq VAR_RESULT, PARTY_SIZE, PacifidlogTown_PokemonCenter_1F_EventScript_NoRoomForEgg
+# 80 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT
+# 81 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	playfanfare MUS_OBTAIN_ITEM
+# 82 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	message PacifidlogTown_PokemonCenter_1F_Text_ReceivedTheEgg
+# 83 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	waitfanfare
+# 84 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	giveegg SPECIES_DRATINI
+# 85 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_9
+# 92 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	removeitem ITEM_YELLOW_SHARD
+# 93 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	msgbox PacifidlogTown_PokemonCenter_1F_ComeBackWithMore, MSGBOX_DEFAULT
-# 72 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_1:
+# 96 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	release
 	end
 
 PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_2:
-# 58 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
-	goto PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo
+# 56 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	msgbox PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_Text_0
 	goto PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_1
+
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_6:
+# 62 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	msgbox PacifidlogTown_PokemonCenter_1F_PseudoManIntroHard, MSGBOX_YESNO
+# 63 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	compare VAR_RESULT, NO
+	goto_if_eq PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_12
+	goto PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_5
+
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_9:
+# 87 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	msgbox PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_Text_1
+# 88 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	setflag FLAG_PSEUDO_EGG
+	goto PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_1
+
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_12:
+# 65 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	goto PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo
+	goto PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_5
+
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_15:
+# 73 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	goto PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo
+	goto PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_14
 
 
 PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo::
-# 78 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 101 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	msgbox PacifidlogTown_PokemonCenter_1F_PseudoEggManDeclined, MSGBOX_DEFAULT
-# 79 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 102 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	release
 	end
 
 
 PacifidlogTown_PokemonCenter_1F_EventScript_ComeBackWithYellowShard::
-# 84 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 107 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	msgbox PacifidlogTown_PokemonCenter_1F_Text_ComeBackWithYellowShard, MSGBOX_DEFAULT
-# 85 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 108 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	release
 	end
 
 
 PacifidlogTown_PokemonCenter_1F_EventScript_NoRoomForEgg::
-# 90 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 113 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	msgbox PacifidlogTown_PokemonCenter_1F_Text_NoRoomForThisEgg, MSGBOX_DEFAULT
-# 91 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 114 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	release
 	end
 
 
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_Text_0:
+# 56 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	.string "Prove us right.$"
+
+PacifidlogTown_PokemonCenter_1F_EventScript_EggMan_Text_1:
+# 87 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	.string "I hope you'll do great things!$"
+
 PacifidlogTown_PokemonCenter_1F_PseudoManIntro::
-# 95 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 118 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	.string "Hello, trainer. I have several rare Eggs\n"
 	.string "here with me.\p"
 	.string "I am currently seeking Yellow Shards,\n"
@@ -171,31 +214,40 @@ PacifidlogTown_PokemonCenter_1F_PseudoManIntro::
 	.string "Yellow Shard in exchange for one of\l"
 	.string "these Eggs?$"
 
+PacifidlogTown_PokemonCenter_1F_PseudoManIntroHard::
+# 127 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+	.string "Hello, trainer. My friends told\n"
+	.string "me about you.\p"
+	.string "The fact that you've made it this\n"
+	.string "far proves your worth as a trainer.\p"
+	.string "Can i entrust one of these rare\n"
+	.string "Eggs to you?$"
+
 PacifidlogTown_PokemonCenter_1F_PseudoEggManDeclined::
-# 104 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 136 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	.string "I see. Please come back if you change\n"
 	.string "your mind.$"
 
 PacifidlogTown_PokemonCenter_1F_Text_ComeBackWithYellowShard::
-# 110 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 142 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	.string "It doesn't look like you have a\n"
 	.string "Yellow Shard. Come back when you do.$"
 
 PacifidlogTown_PokemonCenter_1F_Text_NoRoomForThisEgg::
-# 115 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 147 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	.string "Oh? You've too many Pokémon.\n"
 	.string "There's no room for this Egg…$"
 
 PacifidlogTown_PokemonCenter_1F_Text_HopeYoullWalkPlentyWithEgg::
-# 120 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 152 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	.string "Good! I hope you'll walk plenty with\n"
-	.string "this here Egg!$"
+	.string "this Egg!$"
 
 PacifidlogTown_PokemonCenter_1F_Text_ReceivedTheEgg::
-# 125 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 157 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	.string "{PLAYER} received the Egg.$"
 
 PacifidlogTown_PokemonCenter_1F_ComeBackWithMore::
-# 129 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
+# 161 "data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory"
 	.string "Please come back if you have more\n"
 	.string "Yellow Shards you'd like to exchange.$"

--- a/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory
+++ b/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.pory
@@ -51,27 +51,50 @@ PacifidlogTown_PokemonCenter_1F_Text_OnColonyOfCorsola:
 script PacifidlogTown_PokemonCenter_1F_EventScript_EggMan {
 	lock
 	faceplayer
-	msgbox(PacifidlogTown_PokemonCenter_1F_PseudoManIntro, MSGBOX_YESNO)
-
-	if(var(VAR_RESULT) == NO)
+	if(flag(FLAG_PSEUDO_EGG))
 	{
-		goto(PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo)
+		msgbox("Prove us right.")
 	}
-
-	checkitem(ITEM_YELLOW_SHARD)
-	goto_if_eq(VAR_RESULT, FALSE, PacifidlogTown_PokemonCenter_1F_EventScript_ComeBackWithYellowShard)
-	getpartysize
-	goto_if_eq(VAR_RESULT, PARTY_SIZE, PacifidlogTown_PokemonCenter_1F_EventScript_NoRoomForEgg)
-	msgbox(PacifidlogTown_PokemonCenter_1F_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT)
-	playfanfare(MUS_OBTAIN_ITEM)
-	message(PacifidlogTown_PokemonCenter_1F_Text_ReceivedTheEgg)
-	waitfanfare
-	giveegg(SPECIES_DRATINI)
-	removeitem(ITEM_YELLOW_SHARD)
-	msgbox(PacifidlogTown_PokemonCenter_1F_ComeBackWithMore, MSGBOX_DEFAULT)
+	else
+	{
+		if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+		{
+			msgbox(PacifidlogTown_PokemonCenter_1F_PseudoManIntroHard, MSGBOX_YESNO)
+			if(var(VAR_RESULT) == NO)
+			{
+				goto(PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo)
+			}
+		}
+		else
+		{
+			msgbox(PacifidlogTown_PokemonCenter_1F_PseudoManIntro, MSGBOX_YESNO)
+			if(var(VAR_RESULT) == NO)
+			{
+				goto(PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo)
+			}
+			checkitem(ITEM_YELLOW_SHARD)
+			goto_if_eq(VAR_RESULT, FALSE, PacifidlogTown_PokemonCenter_1F_EventScript_ComeBackWithYellowShard)
+		}
+		getpartysize
+		goto_if_eq(VAR_RESULT, PARTY_SIZE, PacifidlogTown_PokemonCenter_1F_EventScript_NoRoomForEgg)
+		msgbox(PacifidlogTown_PokemonCenter_1F_Text_HopeYoullWalkPlentyWithEgg, MSGBOX_DEFAULT)
+		playfanfare(MUS_OBTAIN_ITEM)
+		message(PacifidlogTown_PokemonCenter_1F_Text_ReceivedTheEgg)
+		waitfanfare
+		giveegg(SPECIES_DRATINI)
+		if (var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+		{
+			msgbox("I hope you'll do great things!")
+			setflag(FLAG_PSEUDO_EGG)
+		}
+		else
+		{
+			removeitem(ITEM_YELLOW_SHARD)
+			msgbox(PacifidlogTown_PokemonCenter_1F_ComeBackWithMore, MSGBOX_DEFAULT)
+		}
+	}
 	release
 	end
-	
 }
 
 script PacifidlogTown_PokemonCenter_1F_EventScript_PseudoEggManManNo {
@@ -101,6 +124,15 @@ text PacifidlogTown_PokemonCenter_1F_PseudoManIntro {
 	"these Eggs?"
 }
 
+text PacifidlogTown_PokemonCenter_1F_PseudoManIntroHard {
+	"Hello, trainer. My friends told\n"
+	"me about you.\p"
+	"The fact that you've made it this\n"
+	"far proves your worth as a trainer.\p"
+	"Can i entrust one of these rare\n"
+	"Eggs to you?"
+}
+
 text PacifidlogTown_PokemonCenter_1F_PseudoEggManDeclined
 {
 	"I see. Please come back if you change\n"
@@ -119,7 +151,7 @@ text PacifidlogTown_PokemonCenter_1F_Text_NoRoomForThisEgg {
 
 text PacifidlogTown_PokemonCenter_1F_Text_HopeYoullWalkPlentyWithEgg {
 	"Good! I hope you'll walk plenty with\n"
-	"this here Egg!"
+	"this Egg!"
 }
 
 text PacifidlogTown_PokemonCenter_1F_Text_ReceivedTheEgg {

--- a/data/maps/ShoalCave_LowTideLowerRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideLowerRoom/scripts.inc
@@ -80,7 +80,7 @@ ShoalCave_LowTideLowerRoom_EventScript_PowerfulMonSummoner_1:
 	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_PowerfulMonSummoner_6
 ShoalCave_LowTideLowerRoom_EventScript_PowerfulMonSummoner_5:
 # 55 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType
 # 56 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	release
 	end
@@ -96,376 +96,485 @@ ShoalCave_LowTideLowerRoom_EventScript_PowerfulMonSummoner_6:
 	goto ShoalCave_LowTideLowerRoom_EventScript_PowerfulMonSummoner_5
 
 
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom::
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType::
 # 61 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	msgbox ShoalCave_LowTideLowerRoom_Text_WhichRoom, MSGBOX_DEFAULT
-# 63 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_0, 0
+	msgbox ShoalCave_LowTideLowerRoom_Text_WhichType, MSGBOX_DEFAULT
 # 64 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_1, 1
-# 65 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_2, 2
-# 66 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_3, MULTI_B_PRESSED
-# 70 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultistack 0, 0, FALSE, 6, FALSE, 0, DYN_MULTICHOICE_CB_NONE
+	compare VAR_GAME_SETTING_DIFFICULTY_MODE, GAME_SETTING_DIFFICULTY_HARD_MODE
+	goto_if_ge ShoalCave_LowTideLowerRoom_EventScript_ChooseType_2
 # 72 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	compare VAR_RESULT, MULTI_B_PRESSED
-	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_2
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_1:
-# 77 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	compare VAR_RESULT, 0
-	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_5
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_4:
-# 81 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	compare VAR_RESULT, 1
-	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_8
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_7:
-# 85 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	compare VAR_RESULT, 2
-	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_11
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_10:
-# 90 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	release
-	end
-
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_2:
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_3, 0
+# 73 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_4, 1
 # 74 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_SummonWomanManNo
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_1
-
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_5:
-# 79 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_4
-
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_8:
-# 83 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_InnerRoom
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_7
-
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_11:
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_1, 2
+# 75 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_2, MULTI_B_PRESSED
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_1:
+# 80 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultistack 0, 0, FALSE, 6, FALSE, 0, DYN_MULTICHOICE_CB_NONE
+# 82 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	compare VAR_RESULT, MULTI_B_PRESSED
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_6
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_5:
 # 87 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_StairsRoom
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_10
-
-
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom::
+	compare VAR_RESULT, 0
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_9
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_8:
+# 91 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	compare VAR_RESULT, 1
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_12
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_11:
 # 95 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	msgbox ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT
-# 97 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_0, SPECIES_GREAT_TUSK
-# 98 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_1, SPECIES_SCREAM_TAIL
+	compare VAR_RESULT, 2
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_15
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_14:
 # 99 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_2, SPECIES_BRUTE_BONNET
-# 100 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_3, SPECIES_FLUTTER_MANE
-# 101 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_4, SPECIES_SLITHER_WING
-# 102 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_5, SPECIES_SANDY_SHOCKS
-# 103 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_6, SPECIES_ROARING_MOON
-# 104 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_7, SPECIES_WALKING_WAKE
-# 105 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_8, SPECIES_GOUGING_FIRE
-# 106 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_9, SPECIES_RAGING_BOLT
-# 107 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_10, MULTI_B_PRESSED
-# 111 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultistack 0, 0, FALSE, 6, FALSE, SPECIES_GREAT_TUSK, DYN_MULTICHOICE_CB_NONE
-# 113 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	compare VAR_RESULT, MULTI_B_PRESSED
-	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_2
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_1:
+	compare VAR_RESULT, 3
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_18
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_17:
+# 108 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	compare VAR_RESULT, 4
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_21
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_20:
 # 118 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon
-# 120 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	release
 	end
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_2:
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_2:
+# 66 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_0, 3
+# 67 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_1, 4
+# 68 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_2, MULTI_B_PRESSED
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_1
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_6:
+# 84 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_SummonWomanManNo
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_5
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_9:
+# 89 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_PastParadox
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_8
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_12:
+# 93 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_FutureParadox
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_11
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_15:
+# 97 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_UltraBeast
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_14
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_18:
+# 101 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	msgbox ShoalCave_LowTideLowerRoom_Text_ConfirmSummonParadoxHard, MSGBOX_YESNO
+# 102 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	compare VAR_RESULT, NO
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_24
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_23:
+# 106 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_ParadoxHard
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_17
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_21:
+# 110 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	msgbox ShoalCave_LowTideLowerRoom_Text_ConfirmSummonUltraBeastHard, MSGBOX_YESNO
+# 111 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	compare VAR_RESULT, NO
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ChooseType_27
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_26:
 # 115 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom
-	goto ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_1
+	goto ShoalCave_LowTideLowerRoom_EventScript_UltraBeastHard
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_20
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_24:
+# 104 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_23
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_27:
+# 113 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType_26
 
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom::
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox::
+# 123 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	msgbox ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT
+# 125 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_0, SPECIES_GREAT_TUSK
 # 126 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	msgbox ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_1, SPECIES_SCREAM_TAIL
+# 127 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_2, SPECIES_BRUTE_BONNET
 # 128 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_0, SPECIES_IRON_TREADS
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_3, SPECIES_FLUTTER_MANE
 # 129 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_1, SPECIES_IRON_BUNDLE
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_4, SPECIES_SLITHER_WING
 # 130 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_2, SPECIES_IRON_HANDS
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_5, SPECIES_SANDY_SHOCKS
 # 131 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_3, SPECIES_IRON_JUGULIS
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_6, SPECIES_ROARING_MOON
 # 132 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_4, SPECIES_IRON_MOTH
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_7, SPECIES_WALKING_WAKE
 # 133 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_5, SPECIES_IRON_THORNS
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_8, SPECIES_GOUGING_FIRE
 # 134 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_6, SPECIES_IRON_VALIANT
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_9, SPECIES_RAGING_BOLT
 # 135 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_7, SPECIES_IRON_LEAVES
-# 136 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_8, SPECIES_IRON_BOULDER
-# 137 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_9, SPECIES_IRON_CROWN
-# 138 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_10, MULTI_B_PRESSED
-# 142 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultistack 0, 0, FALSE, 6, FALSE, SPECIES_IRON_TREADS, DYN_MULTICHOICE_CB_NONE
-# 144 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_10, MULTI_B_PRESSED
+# 139 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultistack 0, 0, FALSE, 6, FALSE, SPECIES_GREAT_TUSK, DYN_MULTICHOICE_CB_NONE
+# 141 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	compare VAR_RESULT, MULTI_B_PRESSED
-	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_2
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_1:
-# 149 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon
-# 151 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	release
-	end
-
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_2:
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_PastParadox_2
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_1:
 # 146 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom
-	goto ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_1
-
-
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom::
-# 157 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	msgbox ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT
-# 159 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_0, SPECIES_NIHILEGO
-# 160 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_1, SPECIES_GUZZLORD
-# 161 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_2, SPECIES_XURKITREE
-# 162 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_3, SPECIES_BUZZWOLE
-# 163 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_4, SPECIES_BLACEPHALON
-# 164 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_5, SPECIES_STAKATAKA
-# 165 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_6, SPECIES_POIPOLE
-# 166 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_7, SPECIES_PHEROMOSA
-# 167 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_8, SPECIES_CELESTEELA
-# 168 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_9, SPECIES_KARTANA
-# 169 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_10, MULTI_B_PRESSED
-# 173 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	dynmultistack 0, 0, FALSE, 6, FALSE, SPECIES_NIHILEGO, DYN_MULTICHOICE_CB_NONE
-# 175 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	compare VAR_RESULT, MULTI_B_PRESSED
-	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_2
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_1:
-# 180 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	goto ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon
-# 182 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 148 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	release
 	end
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_2:
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_2:
+# 143 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType
+	goto ShoalCave_LowTideLowerRoom_EventScript_PastParadox_1
+
+
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox::
+# 154 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	msgbox ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT
+# 156 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_0, SPECIES_IRON_TREADS
+# 157 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_1, SPECIES_IRON_BUNDLE
+# 158 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_2, SPECIES_IRON_HANDS
+# 159 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_3, SPECIES_IRON_JUGULIS
+# 160 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_4, SPECIES_IRON_MOTH
+# 161 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_5, SPECIES_IRON_THORNS
+# 162 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_6, SPECIES_IRON_VALIANT
+# 163 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_7, SPECIES_IRON_LEAVES
+# 164 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_8, SPECIES_IRON_BOULDER
+# 165 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_9, SPECIES_IRON_CROWN
+# 166 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_10, MULTI_B_PRESSED
+# 170 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultistack 0, 0, FALSE, 6, FALSE, SPECIES_IRON_TREADS, DYN_MULTICHOICE_CB_NONE
+# 172 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	compare VAR_RESULT, MULTI_B_PRESSED
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_2
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_1:
 # 177 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom
-	goto ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_1
+	goto ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon
+# 179 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	release
+	end
+
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_2:
+# 174 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType
+	goto ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_1
+
+
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast::
+# 185 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	msgbox ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT
+# 187 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_0, SPECIES_NIHILEGO
+# 188 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_1, SPECIES_GUZZLORD
+# 189 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_2, SPECIES_XURKITREE
+# 190 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_3, SPECIES_BUZZWOLE
+# 191 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_4, SPECIES_BLACEPHALON
+# 192 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_5, SPECIES_STAKATAKA
+# 193 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_6, SPECIES_POIPOLE
+# 194 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_7, SPECIES_PHEROMOSA
+# 195 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_8, SPECIES_CELESTEELA
+# 196 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_9, SPECIES_KARTANA
+# 197 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultipush ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_10, MULTI_B_PRESSED
+# 201 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dynmultistack 0, 0, FALSE, 6, FALSE, SPECIES_NIHILEGO, DYN_MULTICHOICE_CB_NONE
+# 203 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	compare VAR_RESULT, MULTI_B_PRESSED
+	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_2
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_1:
+# 208 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon
+# 210 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	release
+	end
+
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_2:
+# 205 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	goto ShoalCave_LowTideLowerRoom_EventScript_ChooseType
+	goto ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_1
+
+
+ShoalCave_LowTideLowerRoom_EventScript_ParadoxHard::
+# 216 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	randomelement SPECIES_IRON_TREADS, SPECIES_IRON_BUNDLE, SPECIES_IRON_HANDS, SPECIES_IRON_JUGULIS, SPECIES_IRON_MOTH, SPECIES_IRON_THORNS, SPECIES_IRON_VALIANT, SPECIES_IRON_LEAVES, SPECIES_IRON_BOULDER, SPECIES_IRON_CROWN, SPECIES_GREAT_TUSK, SPECIES_SCREAM_TAIL, SPECIES_BRUTE_BONNET, SPECIES_FLUTTER_MANE, SPECIES_SLITHER_WING, SPECIES_SANDY_SHOCKS, SPECIES_ROARING_MOON, SPECIES_WALKING_WAKE, SPECIES_GOUGING_FIRE, SPECIES_RAGING_BOLT
+# 218 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	copyvar VAR_0x8005, VAR_RESULT
+# 219 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	msgbox ShoalCave_LowTideLowerRoom_Text_VeryWell, MSGBOX_DEFAULT
+# 220 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	delay 30
+# 222 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	setwildbattle VAR_0x8005, 80
+# 223 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	waitse
+# 224 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	playmoncry VAR_0x8005, CRY_MODE_ENCOUNTER
+# 225 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	delay 40
+# 226 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	waitmoncry
+# 227 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dowildbattle
+# 228 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	release
+	end
+
+
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeastHard::
+# 233 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	randomelement SPECIES_NIHILEGO, SPECIES_GUZZLORD, SPECIES_XURKITREE, SPECIES_BUZZWOLE, SPECIES_BLACEPHALON, SPECIES_BLACEPHALON, SPECIES_STAKATAKA, SPECIES_POIPOLE, SPECIES_PHEROMOSA, SPECIES_CELESTEELA, SPECIES_KARTANA
+# 235 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	copyvar VAR_0x8005, VAR_RESULT
+# 236 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	msgbox ShoalCave_LowTideLowerRoom_Text_VeryWell, MSGBOX_DEFAULT
+# 237 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	delay 30
+# 239 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	setwildbattle VAR_0x8005, 80
+# 240 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	waitse
+# 241 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	playmoncry VAR_0x8005, CRY_MODE_ENCOUNTER
+# 242 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	delay 40
+# 243 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	waitmoncry
+# 244 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	dowildbattle
+# 245 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	release
+	end
 
 
 ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon::
-# 189 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 250 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	copyvar VAR_0x8005, VAR_RESULT
-# 190 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 251 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	bufferspeciesname STR_VAR_1, VAR_0x8005
-# 191 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 252 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	msgbox ShoalCave_LowTideLowerRoom_Text_ConfirmSummon, MSGBOX_YESNO
-# 193 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 254 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	compare VAR_RESULT, NO
 	goto_if_eq ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon_2
 ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon_1:
-# 198 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 259 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	msgbox ShoalCave_LowTideLowerRoom_Text_VeryWell, MSGBOX_DEFAULT
-# 199 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 260 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	delay 30
-# 201 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 262 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	setwildbattle VAR_0x8005, 50
-# 202 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 263 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	waitse
-# 203 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 264 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	playmoncry VAR_0x8005, CRY_MODE_ENCOUNTER
-# 204 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 265 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	delay 40
-# 205 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 266 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	waitmoncry
-# 206 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 267 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	dowildbattle
-# 207 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 268 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	release
 	end
 
 ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon_2:
-# 195 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 256 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	goto ShoalCave_LowTideLowerRoom_EventScript_SummonWomanManNo
 	goto ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon_1
 
 
 ShoalCave_LowTideLowerRoom_EventScript_SummonWomanManNo::
-# 213 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 274 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	msgbox ShoalCave_LowTideLowerRoom_SummonWomanDeclined, MSGBOX_DEFAULT
-# 214 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 275 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	release
 	end
 
 
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_0:
-# 63 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	.string "Entrance Room$"
-
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_1:
-# 64 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	.string "Inner Room$"
-
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_2:
-# 65 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
-	.string "Stairs Room$"
-
-ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom_Text_3:
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_0:
 # 66 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	.string "Paradox$"
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_1:
+# 67 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	.string "Ultra Beast$"
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_2:
+# 68 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Cancel$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_0:
-# 97 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_3:
+# 72 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	.string "Past Paradox$"
+
+ShoalCave_LowTideLowerRoom_EventScript_ChooseType_Text_4:
+# 73 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	.string "Future Paradox$"
+
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_0:
+# 125 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Great Tusk$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_1:
-# 98 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_1:
+# 126 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Scream Tail$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_2:
-# 99 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_2:
+# 127 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Brute Bonnet$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_3:
-# 100 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_3:
+# 128 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Flutter Mane$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_4:
-# 101 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_4:
+# 129 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Slither Wing$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_5:
-# 102 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_5:
+# 130 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Sandy Shocks$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_6:
-# 103 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_6:
+# 131 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Roaring Moon$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_7:
-# 104 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_7:
+# 132 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Walking Wake$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_8:
-# 105 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_8:
+# 133 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Gouging Fire$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_9:
-# 106 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_9:
+# 134 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Raging Bolt$"
 
-ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom_Text_10:
-# 107 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_PastParadox_Text_10:
+# 135 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Back$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_0:
-# 128 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_0:
+# 156 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Treads$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_1:
-# 129 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_1:
+# 157 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Bundle$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_2:
-# 130 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_2:
+# 158 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Hands$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_3:
-# 131 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_3:
+# 159 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Jugulis$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_4:
-# 132 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_4:
+# 160 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Moth$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_5:
-# 133 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_5:
+# 161 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Thorns$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_6:
-# 134 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_6:
+# 162 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Valiant$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_7:
-# 135 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_7:
+# 163 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Leaves$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_8:
-# 136 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_8:
+# 164 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Boulder$"
 
-ShoalCave_LowTideLowerRoom_EventScript_InnerRoom_Text_9:
-# 137 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_FutureParadox_Text_9:
+# 165 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Iron Crown$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_0:
-# 159 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_0:
+# 187 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Nihilego$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_1:
-# 160 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_1:
+# 188 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Guzzlord$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_2:
-# 161 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_2:
+# 189 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Xurkitree$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_3:
-# 162 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_3:
+# 190 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Buzzwole$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_4:
-# 163 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_4:
+# 191 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Blacephalon$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_5:
-# 164 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_5:
+# 192 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Stakataka$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_6:
-# 165 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_6:
+# 193 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Poipole$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_7:
-# 166 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_7:
+# 194 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Pheromosa$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_8:
-# 167 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_8:
+# 195 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Celesteela$"
 
-ShoalCave_LowTideLowerRoom_EventScript_StairsRoom_Text_9:
-# 168 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_EventScript_UltraBeast_Text_9:
+# 196 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Kartana$"
 
 ShoalCave_LowTideLowerRoom_Text_SummonerIntro::
-# 219 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 280 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Hello, young trainer.\p"
 	.string "I've come to this remote location\n"
 	.string "because I have learned a powerful\l"
@@ -476,30 +585,40 @@ ShoalCave_LowTideLowerRoom_Text_SummonerIntro::
 	.string "here so you can battle it?$"
 
 ShoalCave_LowTideLowerRoom_Text_SummonerIntroQuick::
-# 230 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 291 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Would you like me to summon a Pokémon\n"
 	.string "here so you can battle it?$"
 
-ShoalCave_LowTideLowerRoom_Text_WhichRoom::
-# 235 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+ShoalCave_LowTideLowerRoom_Text_WhichType::
+# 296 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Which room would you like me to summon a\n"
 	.string "Pokémon from?$"
 
 ShoalCave_LowTideLowerRoom_Text_WhichPokemon::
-# 240 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 301 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Which Pokémon would you like me to\n"
 	.string "summon so you can battle?$"
 
 ShoalCave_LowTideLowerRoom_Text_ConfirmSummon::
-# 245 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 306 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "So you want me to summon a\n"
 	.string "{STR_VAR_1} for you to battle?$"
 
+ShoalCave_LowTideLowerRoom_Text_ConfirmSummonParadoxHard::
+# 311 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	.string "So you want me to summon a\n"
+	.string "Paradox Pokémon for you to battle?$"
+
+ShoalCave_LowTideLowerRoom_Text_ConfirmSummonUltraBeastHard::
+# 316 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+	.string "So you want me to summon an\n"
+	.string "Ultra Beast for you to battle?$"
+
 ShoalCave_LowTideLowerRoom_Text_VeryWell::
-# 250 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 321 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "Very well, prepare yourself for battle.$"
 
 ShoalCave_LowTideLowerRoom_SummonWomanDeclined::
-# 254 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
+# 325 "data/maps/ShoalCave_LowTideLowerRoom/scripts.pory"
 	.string "I see. Let me know if you change\n"
 	.string "your mind.$"

--- a/data/maps/ShoalCave_LowTideLowerRoom/scripts.pory
+++ b/data/maps/ShoalCave_LowTideLowerRoom/scripts.pory
@@ -52,18 +52,28 @@ script ShoalCave_LowTideLowerRoom_EventScript_PowerfulMonSummoner {
 		goto(ShoalCave_LowTideLowerRoom_EventScript_SummonWomanManNo)
 	}
 
-	goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom)
+	goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseType)
 	release
 	end
 }
 
-script ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom {
-	msgbox(ShoalCave_LowTideLowerRoom_Text_WhichRoom, MSGBOX_DEFAULT)
+script ShoalCave_LowTideLowerRoom_EventScript_ChooseType {
+	msgbox(ShoalCave_LowTideLowerRoom_Text_WhichType, MSGBOX_DEFAULT)
 
-	dynmultipush("Entrance Room", 0)
-	dynmultipush("Inner Room", 1)
-	dynmultipush("Stairs Room", 2)
-    dynmultipush("Cancel", MULTI_B_PRESSED)
+
+	if(var(VAR_GAME_SETTING_DIFFICULTY_MODE) >= GAME_SETTING_DIFFICULTY_HARD_MODE)
+	{
+		dynmultipush("Paradox", 3)
+		dynmultipush("Ultra Beast", 4)
+		dynmultipush("Cancel", MULTI_B_PRESSED)
+	}
+	else
+	{
+		dynmultipush("Past Paradox", 0)
+		dynmultipush("Future Paradox", 1)
+		dynmultipush("Ultra Beast", 2)
+		dynmultipush("Cancel", MULTI_B_PRESSED)
+	}
 
 	//.macro dynmultistack left:req, top:req, ignoreBPress:req, maxBeforeScroll:req, shouldSort:req, initialSelected:req, callbacks:req
     // // setting initial selected to a non-existant ID will always have it point to the first option
@@ -76,22 +86,40 @@ script ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom {
 
 	if (var(VAR_RESULT) == 0)
 	{
-		goto(ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom)
+		goto(ShoalCave_LowTideLowerRoom_EventScript_PastParadox)
 	}
 	if (var(VAR_RESULT) == 1)
 	{
-		goto(ShoalCave_LowTideLowerRoom_EventScript_InnerRoom)
+		goto(ShoalCave_LowTideLowerRoom_EventScript_FutureParadox)
 	}
 	if (var(VAR_RESULT) == 2)
 	{
-		goto(ShoalCave_LowTideLowerRoom_EventScript_StairsRoom)
+		goto(ShoalCave_LowTideLowerRoom_EventScript_UltraBeast)
+	}
+	if (var(VAR_RESULT) == 3)
+	{
+		msgbox(ShoalCave_LowTideLowerRoom_Text_ConfirmSummonParadoxHard, MSGBOX_YESNO)
+		if(var(VAR_RESULT) == NO)
+		{
+			goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseType)
+		}
+		goto(ShoalCave_LowTideLowerRoom_EventScript_ParadoxHard)
+	}
+	if (var(VAR_RESULT) == 4)
+	{
+		msgbox(ShoalCave_LowTideLowerRoom_Text_ConfirmSummonUltraBeastHard, MSGBOX_YESNO)
+		if(var(VAR_RESULT) == NO)
+		{
+			goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseType)
+		}
+		goto(ShoalCave_LowTideLowerRoom_EventScript_UltraBeastHard)
 	}
 
 	release
 	end
 }
 
-script ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom {
+script ShoalCave_LowTideLowerRoom_EventScript_PastParadox {
 	msgbox(ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT)
 
 	dynmultipush("Great Tusk",   SPECIES_GREAT_TUSK)
@@ -112,7 +140,7 @@ script ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom {
 
 	if (var(VAR_RESULT) == MULTI_B_PRESSED) 
 	{
-		goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom)
+		goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseType)
 	}
 
 	goto(ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon)
@@ -122,7 +150,7 @@ script ShoalCave_LowTideLowerRoom_EventScript_EntranceRoom {
 
 }
 
-script ShoalCave_LowTideLowerRoom_EventScript_InnerRoom {
+script ShoalCave_LowTideLowerRoom_EventScript_FutureParadox {
 	msgbox(ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT)
 
 	dynmultipush("Iron Treads",   SPECIES_IRON_TREADS)
@@ -143,7 +171,7 @@ script ShoalCave_LowTideLowerRoom_EventScript_InnerRoom {
 
 	if (var(VAR_RESULT) == MULTI_B_PRESSED) 
 	{
-		goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom)
+		goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseType)
 	}
 
 	goto(ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon)
@@ -153,7 +181,7 @@ script ShoalCave_LowTideLowerRoom_EventScript_InnerRoom {
 
 }
 
-script ShoalCave_LowTideLowerRoom_EventScript_StairsRoom {
+script ShoalCave_LowTideLowerRoom_EventScript_UltraBeast {
 	msgbox(ShoalCave_LowTideLowerRoom_Text_WhichPokemon, MSGBOX_DEFAULT)
 
 	dynmultipush("Nihilego",    SPECIES_NIHILEGO)
@@ -174,7 +202,7 @@ script ShoalCave_LowTideLowerRoom_EventScript_StairsRoom {
 
 	if (var(VAR_RESULT) == MULTI_B_PRESSED) 
 	{
-		goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseRoom)
+		goto(ShoalCave_LowTideLowerRoom_EventScript_ChooseType)
 	}
 
 	goto(ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon)
@@ -184,6 +212,39 @@ script ShoalCave_LowTideLowerRoom_EventScript_StairsRoom {
 
 }
 
+script ShoalCave_LowTideLowerRoom_EventScript_ParadoxHard {
+	randomelement(SPECIES_IRON_TREADS, SPECIES_IRON_BUNDLE, SPECIES_IRON_HANDS, SPECIES_IRON_JUGULIS, SPECIES_IRON_MOTH, SPECIES_IRON_THORNS, SPECIES_IRON_VALIANT, SPECIES_IRON_LEAVES, SPECIES_IRON_BOULDER, SPECIES_IRON_CROWN, SPECIES_GREAT_TUSK, SPECIES_SCREAM_TAIL, SPECIES_BRUTE_BONNET, SPECIES_FLUTTER_MANE, SPECIES_SLITHER_WING, SPECIES_SANDY_SHOCKS, SPECIES_ROARING_MOON, SPECIES_WALKING_WAKE, SPECIES_GOUGING_FIRE, SPECIES_RAGING_BOLT)
+
+	copyvar(VAR_0x8005, VAR_RESULT)
+	msgbox(ShoalCave_LowTideLowerRoom_Text_VeryWell, MSGBOX_DEFAULT)
+	delay(30)
+
+	setwildbattle(VAR_0x8005, 80)
+	waitse
+	playmoncry(VAR_0x8005, CRY_MODE_ENCOUNTER)
+	delay(40)
+	waitmoncry
+	dowildbattle
+	release
+	end
+}
+
+script ShoalCave_LowTideLowerRoom_EventScript_UltraBeastHard {
+	randomelement(SPECIES_NIHILEGO, SPECIES_GUZZLORD, SPECIES_XURKITREE, SPECIES_BUZZWOLE, SPECIES_BLACEPHALON, SPECIES_BLACEPHALON, SPECIES_STAKATAKA, SPECIES_POIPOLE, SPECIES_PHEROMOSA, SPECIES_CELESTEELA, SPECIES_KARTANA)
+
+	copyvar(VAR_0x8005, VAR_RESULT)
+	msgbox(ShoalCave_LowTideLowerRoom_Text_VeryWell, MSGBOX_DEFAULT)
+	delay(30)
+
+	setwildbattle(VAR_0x8005, 80)
+	waitse
+	playmoncry(VAR_0x8005, CRY_MODE_ENCOUNTER)
+	delay(40)
+	waitmoncry
+	dowildbattle
+	release
+	end
+}
 
 script ShoalCave_LowTideLowerRoom_EventScript_ConfirmAndUseSummon {
 	copyvar(VAR_0x8005, VAR_RESULT)
@@ -232,7 +293,7 @@ text ShoalCave_LowTideLowerRoom_Text_SummonerIntroQuick {
 	"here so you can battle it?"
 }
 
-text ShoalCave_LowTideLowerRoom_Text_WhichRoom {
+text ShoalCave_LowTideLowerRoom_Text_WhichType {
 	"Which room would you like me to summon a\n"
 	"Pokémon from?"
 }
@@ -245,6 +306,16 @@ text ShoalCave_LowTideLowerRoom_Text_WhichPokemon {
 text ShoalCave_LowTideLowerRoom_Text_ConfirmSummon {
 	"So you want me to summon a\n"
 	"{STR_VAR_1} for you to battle?"
+}
+
+text ShoalCave_LowTideLowerRoom_Text_ConfirmSummonParadoxHard {
+	"So you want me to summon a\n"
+	"Paradox Pokémon for you to battle?"
+}
+
+text ShoalCave_LowTideLowerRoom_Text_ConfirmSummonUltraBeastHard {
+	"So you want me to summon an\n"
+	"Ultra Beast for you to battle?"
 }
 
 text ShoalCave_LowTideLowerRoom_Text_VeryWell {

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -52,13 +52,13 @@
 #define FLAG_USING_POKEMONPCMENU       0x26
 #define FLAG_STOP_ENCOUNTERS           0x27
 #define FLAG_PARTY_MOVES               0x28
-#define FLAG_UNUSED_0x29               0x29 // unused
+#define FLAG_STARTER_EGG               0x29
 #define FLAG_RECEIVED_OLDALE_EGG       0x2A
 #define FLAG_RECEIVED_SETUP_TMS        0x2B
-#define FLAG_UNUSED_0x2C               0x2C // unused
+#define FLAG_PSEUDO_EGG                0x2C 
 #define FLAG_RIVAL_110                 0x2D
 #define FLAG_DAWN_111                  0x2E
-#define FLAG_UNUSED_0x2F               0x2F // unused
+#define FLAG_LAVARIDGE_EGG             0x2F
 #define FLAG_RECEIVED_MEGA_STONES      0x30
 #define FLAG_RECEIVED_TMS_FROM_TUTOR   0x31
 #define FLAG_DECLINED_DANCE_BATTLE     0x32


### PR DESCRIPTION
## Description
Hard mode changes:
- Fallarbor, Lavaridge and Pacifidlog eggs are limited to one. You still get to choose the type for the Fallarbor egg. 
- The summoning lady in shoal cave lets you pick between a random paradox and a random ultra beast. 

## Images

https://github.com/user-attachments/assets/0c5a7202-0da0-4342-845d-2372041265bb


## **People who collaborated with me in this PR**
Rain for the macros 

## Feature(s) this PR does NOT handle:
- I will change the VR summoning lady to summon a random strong legendary
- I will add a summoning lady on 121 for a semi-strong legendary
- I will remove roamers altogether. 

## Things to note in the release changelog:
- Fallarbor, Lavaridge and Pacifidlog eggs are limited to one in Hard mode. 
- The Shoal Cave summoning is a random Pokémon from a pool of Paradox or Ultra Beast in Hard mode.

## **Discord contact info**
MaximeGr
