### PR TITLE
Crits are now 1/16

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -2,7 +2,7 @@
 #define GUARD_CONFIG_BATTLE_H
 
 // Calculation settings
-#define B_CRIT_CHANCE               GEN_LATEST // Chances of a critical hit landing. See CalcCritChanceStage. Gen6+ chances guarantee that Farfetch'd and Sirfetch'd always get critical hits while holding a Leek and using high-crit ratio moves.
+#define B_CRIT_CHANCE               GEN_6 // Chances of a critical hit landing. See CalcCritChanceStage. Gen6+ chances guarantee that Farfetch'd and Sirfetch'd always get critical hits while holding a Leek and using high-crit ratio moves.
 #define B_CRIT_MULTIPLIER           GEN_LATEST // In Gen6+, critical hits multiply damage by 1.5 instead of 2.
 #define B_PARALYSIS_SPEED           GEN_LATEST // In Gen7+, Speed is decreased by 50% instead of 75%.
 #define B_CONFUSION_SELF_DMG_CHANCE GEN_LATEST // In Gen7+, confusion has a 33.3% of self-damage, instead of 50%.


### PR DESCRIPTION
## Description
- Critical hits are now 1/16 instead of 1/24. 

## Issue(s) that this PR fixes
Players being ASS 

## **People who collaborated with me in this PR**
W Iriv

## Things to note in the release changelog:
- Critical hits are now 1/16 instead of 1/24. 

## **Discord contact info**
MaximeGr
