### PR TITLE
Added a submenu for field moves to not overcrowd the party menu

### DIFF
--- a/include/constants/party_menu.h
+++ b/include/constants/party_menu.h
@@ -112,6 +112,7 @@
 #define SELECTWINDOW_MOVE_RELEARN_ONE  7
 #define SELECTWINDOW_HEXORB            8 // hexorb Branch
 #define SELECTWINDOW_MODE              9
-#define SELECTWINDW_SETHP              10
+#define SELECTWINDOW_SETHP             10
+#define SELECTWINDOW_OVERWORLDMOVES    11
 
 #endif // GUARD_CONSTANTS_PARTY_MENU_H

--- a/include/strings.h
+++ b/include/strings.h
@@ -2007,6 +2007,7 @@ extern const u8 gText_Register[];
 extern const u8 gText_Trade4[];
 extern const u8 gText_Summary5[];
 extern const u8 gText_Switch2[];
+extern const u8 gText_OverworldMoves[];
 extern const u8 gText_Item[];
 extern const u8 gText_NotPkmnOtherTrainerWants[];
 extern const u8 gText_ThatIsntAnEgg[];

--- a/src/data/party_menu.h
+++ b/src/data/party_menu.h
@@ -724,6 +724,17 @@ static const struct WindowTemplate sApplyModeWindowTemplate =
     .baseBlock = 0x299,
 };
 
+static const struct WindowTemplate sOverworldMovesWindowTemplate =
+{
+    .bg = 2,
+    .tilemapLeft = 19,
+    .tilemapTop = 9,
+    .width = 10,
+    .height = 10,
+    .paletteNum = 15,
+    .baseBlock = 0x299,
+};
+
 static const struct WindowTemplate sSetHpWindowTemplate =
 {
     .bg = 2,
@@ -935,6 +946,7 @@ struct
     [MENU_TXC] = {gText_ToxicMenu, CursorCb_Toxic},
     [MENU_SLP] = {gText_SleepMenu, CursorCb_Sleep},
     [MENU_NICKNAME] = {gText_Nickname, CursorCb_Nickname},
+    [MENU_OVERWORLD_MOVES] = {gText_OverworldMoves, CursorCb_OverworldMoves},
     [MENU_SWITCH] = {gText_Switch2, CursorCb_Switch},
     [MENU_CANCEL1] = {gText_Cancel2, CursorCb_Cancel1},
     [MENU_ITEM] = {gText_Item, CursorCb_Item},
@@ -993,7 +1005,8 @@ static const u8 sPartyMenuAction_LvlUpEggCancel[] = {MENU_LEVEL_UP_MOVES, MENU_E
 static const u8 sPartyMenuAction_LvlUpCancel[] = {MENU_LEVEL_UP_MOVES, MENU_CANCEL2};
 static const u8 sPartyMenuAction_EggCancel[] = {MENU_EGG_MOVES, MENU_CANCEL2};
 static const u8 sPartyMenuAction_Hexorb[] = {MENU_INFLICT_SLEEP, MENU_INFLICT_POISON, MENU_INFLICT_BURN, MENU_INFLICT_FREEZE_FROSTBITE, MENU_INFLICT_PARALYSIS, MENU_CANCEL1}; // hexorb Branch
-static const u8 sPartyMenuAction_Mode[] = {MENU_HP, MENU_BRN, MENU_PAR, MENU_FSB, MENU_PSN, MENU_TXC, MENU_SLP, MENU_CANCEL1};
+static const u8 sPartyMenuAction_Mode[] = {MENU_HP, MENU_BRN, MENU_PAR, MENU_FSB, MENU_PSN, MENU_TXC, MENU_SLP, MENU_CANCEL2};
+static const u8 sPartyMenuAction_Overworld[] = {MENU_OVERWORLD_MOVES, MENU_CANCEL2};
 
 
 static const u8 *const sPartyMenuActions[] =
@@ -1019,6 +1032,7 @@ static const u8 *const sPartyMenuActions[] =
     [ACTIONS_RELEARN_MOVES_EGG_ONLY] = sPartyMenuAction_EggCancel,
     [ACTIONS_HEXORB] = sPartyMenuAction_Hexorb, // hexorb Branch
     [ACTIONS_MODE] = sPartyMenuAction_Mode,
+    [ACTIONS_OVERWORLD] = sPartyMenuAction_Overworld,
 };
 
 static const u8 sPartyMenuActionCounts[] =
@@ -1044,6 +1058,7 @@ static const u8 sPartyMenuActionCounts[] =
     [ACTIONS_RELEARN_MOVES_EGG_ONLY] = ARRAY_COUNT(sPartyMenuAction_EggCancel),
     [ACTIONS_HEXORB] = ARRAY_COUNT(sPartyMenuAction_Hexorb), // hexorb Branch
     [ACTIONS_MODE] = ARRAY_COUNT(sPartyMenuAction_Mode),
+    [ACTIONS_OVERWORLD] = ARRAY_COUNT(sPartyMenuAction_Overworld),
 };
 
 static const u16 sFieldMoves[FIELD_MOVES_COUNT + 1] =

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -84,6 +84,7 @@
 
 enum {
     MENU_SUMMARY,
+    MENU_OVERWORLD_MOVES,
     MENU_SWITCH,
     MENU_RELEARN_BOTH,
     MENU_RELEARN_LVL_UP,
@@ -146,6 +147,7 @@ enum {
     ACTIONS_SUMMARY_ONLY,
     ACTIONS_ITEM,
     ACTIONS_MODE,
+    ACTIONS_OVERWORLD,
     ACTIONS_MAIL,
     ACTIONS_REGISTER,
     ACTIONS_TRADE,
@@ -524,6 +526,7 @@ static void CursorCb_Toxic(u8);
 static void CursorCb_Sleep(u8);
 static void UpdateStatus(u8, u16);// end of predmg menu
 static void CursorCb_Switch(u8);
+static void CursorCb_OverworldMoves(u8);
 static void CursorCb_Cancel1(u8);
 static void CursorCb_Item(u8);
 static void CursorCb_Give(u8);
@@ -2944,8 +2947,11 @@ static u8 DisplaySelectionWindow(u8 windowType)
     case SELECTWINDOW_MODE:
         window = sApplyModeWindowTemplate;
         break;
-    case SELECTWINDW_SETHP:
+    case SELECTWINDOW_SETHP:
         window = sSetHpWindowTemplate;
+        break;
+    case SELECTWINDOW_OVERWORLDMOVES:
+        window = sOverworldMovesWindowTemplate;
         break;
         // Start hexorb Branch
     case SELECTWINDOW_HEXORB:
@@ -3009,11 +3015,54 @@ static void PartyMenuDisplayYesNoMenu(void)
 
 static void SetPartyMonSelectionActions(struct Pokemon *mons, u8 slotId, u8 action)
 {
-    u8 i;
+    u8 i, j;
 
     if (action == ACTIONS_NONE)
     {
         SetPartyMonFieldSelectionActions(mons, slotId);
+    }
+    else if (action == ACTIONS_OVERWORLD)
+    {
+        // Build field moves list for Overworld menu
+        sPartyMenuInternal->numActions = 0;
+        
+        // Add field moves that the pokemon knows
+        for (i = 0; i < MAX_MON_MOVES; i++)
+        {
+            for (j = 0; j != FIELD_MOVES_COUNT; j++)
+            {
+                if (GetMonData(&mons[slotId], i + MON_DATA_MOVE1) == sFieldMoves[j])
+                {
+                    // If Mon already knows FLY and the HM is in the bag, prevent it from being added to action list
+                    if (sFieldMoves[j] != MOVE_FLY || !CheckBagHasItem(ITEM_HM02, 1)){
+                        // If Mon already knows FLASH and the HM is in the bag, prevent it from being added to action list
+                        if (sFieldMoves[j] != MOVE_FLASH || !CheckBagHasItem(ITEM_HM05, 1)){ 
+                            if (sFieldMoves[j] != MOVE_DIG ){
+                                if (sFieldMoves[j] != MOVE_TELEPORT){
+                                    AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, j + MENU_FIELD_MOVES);
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        
+        // Add learnable field moves if < 4 moves are shown
+        if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_FLY) != 1) && CheckBagHasItem(ITEM_HM02, 1)) 
+            AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 8 + MENU_FIELD_MOVES);
+        
+        if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_FLASH) != 1) && CheckBagHasItem(ITEM_HM05, 1)) 
+            AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 1 + MENU_FIELD_MOVES);
+        
+        if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_DIG) != 1)) 
+            AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 10 + MENU_FIELD_MOVES);
+        
+        if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_TELEPORT) != 1)) 
+            AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 9 + MENU_FIELD_MOVES);
+        
+        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, MENU_CANCEL2);
     }
     else
     {
@@ -3030,43 +3079,43 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
     sPartyMenuInternal->numActions = 0;
     AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, MENU_SUMMARY);
 
-    // If Mon can learn Fly and action list consists of < 4 moves, add FLY to action list
-    if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_FLY) != 1) && CheckBagHasItem(ITEM_HM02, 1)) 
-        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 8 + MENU_FIELD_MOVES);
+    // Check if pokemon has any field moves
+    bool8 hasFieldMove = FALSE;
     
-    // If Mon can learn Flash and action list consists of < 4 moves, add FLASH to action list
-    if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_FLASH) != 1) && CheckBagHasItem(ITEM_HM05, 1)) 
-        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 1 + MENU_FIELD_MOVES);
-
-    // Add field moves to action list
+    // Check if Mon already knows any field moves
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         for (j = 0; j != FIELD_MOVES_COUNT; j++)
         {
             if (GetMonData(&mons[slotId], i + MON_DATA_MOVE1) == sFieldMoves[j])
             {
-                // If Mon already knows FLY and the HM is in the bag, prevent it from being added to action list
-                if (sFieldMoves[j] != MOVE_FLY || !CheckBagHasItem(ITEM_HM02, 1)){
-                    // If Mon already knows FLASH and the HM is in the bag, prevent it from being added to action list
-                    if (sFieldMoves[j] != MOVE_FLASH || !CheckBagHasItem(ITEM_HM05, 1)){ 
-                        if (sFieldMoves[j] != MOVE_DIG ){
-                            if (sFieldMoves[j] != MOVE_TELEPORT){
-                                AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, j + MENU_FIELD_MOVES);
-                            }
-                        }
-                    }
-                }
+                hasFieldMove = TRUE;
                 break;
             }
         }
+        if (hasFieldMove)
+            break;
     }
     
+    // If Mon can learn Fly and action list consists of < 4 moves, add FLY to action list
+    if (!hasFieldMove && sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_FLY) != 1) && CheckBagHasItem(ITEM_HM02, 1)) 
+        hasFieldMove = TRUE;
+    
+    // If Mon can learn Flash and action list consists of < 4 moves, add FLASH to action list
+    if (!hasFieldMove && sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_FLASH) != 1) && CheckBagHasItem(ITEM_HM05, 1)) 
+        hasFieldMove = TRUE;
+    
     // If Mon can learn Dig and action list consists of < 4 moves, add DIG to action list
-    if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_DIG) != 1)) 
-        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 10 + MENU_FIELD_MOVES);
+    if (!hasFieldMove && sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_DIG) != 1)) 
+        hasFieldMove = TRUE;
+    
     // If Mon can learn Teleport and action list consists of < 4 moves, add TELEPORT to action list
-    if (sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_TELEPORT) != 1)) 
-        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 9 + MENU_FIELD_MOVES);
+    if (!hasFieldMove && sPartyMenuInternal->numActions < 5 && (CanTeachMove(&mons[slotId], MOVE_TELEPORT) != 1)) 
+        hasFieldMove = TRUE;
+    
+    // Add Overworld menu item if Mon has field moves
+    if (hasFieldMove)
+        AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, MENU_OVERWORLD_MOVES);
 
     if (!InBattlePike())
     {
@@ -8318,6 +8367,18 @@ static void CursorCb_Mode(u8 taskId)
     gTasks[taskId].func = Task_HandleSelectionMenuInput;
 }
 
+static void CursorCb_OverworldMoves(u8 taskId)
+{
+    PlaySE(SE_SELECT);
+    PartyMenuRemoveWindow(&sPartyMenuInternal->windowId[0]);
+    PartyMenuRemoveWindow(&sPartyMenuInternal->windowId[1]);
+    SetPartyMonSelectionActions(gPlayerParty, gPartyMenu.slotId, ACTIONS_OVERWORLD);
+    DisplaySelectionWindow(SELECTWINDOW_OVERWORLDMOVES);
+    DisplayPartyMenuStdMessage(PARTY_MSG_DO_WHAT_WITH_MON);
+    gTasks[taskId].data[0] = 0xFF;
+    gTasks[taskId].func = Task_HandleSelectionMenuInput;
+}
+
 #define thealthPoints data[8]
 
 static void CursorCb_SetHp(u8 taskId)
@@ -8326,7 +8387,7 @@ static void CursorCb_SetHp(u8 taskId)
     PartyMenuRemoveWindow(&sPartyMenuInternal->windowId[0]);
     PartyMenuRemoveWindow(&sPartyMenuInternal->windowId[1]);
     SetPartyMonSelectionActions(gPlayerParty, gPartyMenu.slotId, ACTIONS_MODE);
-    // DisplaySelectionWindow(SELECTWINDW_SETHP);
+    // DisplaySelectionWindow(SELECTWINDOW_SETHP);
     sPartyMenuInternal->windowId[0] = AddWindow(&sSetHpWindowTemplate);
     DrawStdFrameWithCustomTileAndPalette(sPartyMenuInternal->windowId[0], FALSE, 0x4F, 13);
     PrintHP(sPartyMenuInternal->windowId[0], 1);

--- a/src/strings.c
+++ b/src/strings.c
@@ -281,6 +281,7 @@ const u8 gText_PokedollarVar1[] = _("¥{STR_VAR_1}");
 const u8 gText_Shift[] = _("Shift");
 const u8 gText_SendOut[] = _("Send Out");
 const u8 gText_Switch2[] = _("Switch");
+const u8 gText_OverworldMoves[] = _("Overworld");
 const u8 gText_Summary5[] = _("Summary");
 const u8 gText_Moves[] = _("Moves"); // Unused
 const u8 gText_Enter[] = _("Enter");


### PR DESCRIPTION
## Description
- Added a submenu for field moves to not overcrowd the party menu
- Fixed mode submenu so cancel returns to the party menu instead of just leaving menu altogether 

The "Overworld" menu item does not appear if the Pokémon has no field moves. 

## Images
<img width="725" height="484" alt="image" src="https://github.com/user-attachments/assets/21f20399-4f43-483a-a8f4-79abbab4310f" />

## Things to note in the release changelog:
- Added a submenu for field moves to not overcrowd the party menu

## **Discord contact info**
MaximeGr
