### PR TITLE
Remove items from wilds in hard mode

### DIFF
--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -1269,6 +1269,8 @@ static void DexNavGenerateMoveset(u16 species, u8 searchLevel, u8 encounterLevel
 
 static u16 DexNavGenerateHeldItem(u16 species, u8 searchLevel)
 {
+    if (VarGet(VAR_GAME_SETTING_DIFFICULTY_MODE)>=GAME_SETTING_DIFFICULTY_HARD_MODE)
+        return ITEM_NONE;
     u16 randVal = Random() % 100;
     u8 searchLevelInfluence = searchLevel >> 1;
     u16 item1 = gSpeciesInfo[species].itemCommon;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -7197,6 +7197,8 @@ static inline bool32 CanFirstMonBoostHeldItemRarity(void)
 
 void SetWildMonHeldItem(void)
 {
+    if (VarGet(VAR_GAME_SETTING_DIFFICULTY_MODE)>=GAME_SETTING_DIFFICULTY_HARD_MODE)
+        return;
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LEGENDARY | BATTLE_TYPE_TRAINER | BATTLE_TYPE_PYRAMID | BATTLE_TYPE_PIKE))
       && !gDexnavBattle)
     {


### PR DESCRIPTION
## Description
- DexNav and normal wild encounters can't hold items in Hard Mode. 
The items will be distributed to the player instead. 

## Things to note in the release changelog:
- DexNav and normal wild encounters can't hold items in Hard Mode. 

## **Discord contact info**
MaximeGr
