### PR TITLE
Add fake out to support moves

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2882,7 +2882,8 @@ bool32 IsSupportMove(u32 move, u32 effect)
         return FALSE;
         
     return gMovesInfo[move].category == DAMAGE_CATEGORY_STATUS
-        || IsTrappingMove(move);
+        || IsTrappingMove(move)
+        || move == MOVE_FAKE_OUT;
 }
 
 static inline bool32 IsMoveSleepClauseTrigger(u32 move)


### PR DESCRIPTION
## Description
Adding Fake out to support moves for support switch ai 

## Things to note in the release changelog:
- Fake out is considered a support move

## **Discord contact info**
MaximeGr
