### PR TITLE
consistent hits on multi hit moves for ease of calc

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -658,15 +658,14 @@ static inline void CalcDynamicMoveDamage(struct DamageCalculationData *damageCal
         }
         else if (holdEffectAtk == HOLD_EFFECT_LOADED_DICE)
         {
-            median *= 9;
-            median /= 2;
+            median *= 4;
             minimum *= 4;
-            maximum *= 5;
+            maximum *= 4;
         }
         else
         {
             median *= 3;
-            minimum *= 2;
+            minimum *= 3;
             maximum *= 3;
         }
         break;


### PR DESCRIPTION
## Description
- Normal multi-hit moves calc with 3 hits always, loaded dice with 4. 
- This is meant to make calcing more intuitive as the current implementation has tripped up players many times. 

## Things to note in the release changelog:
- Normal multi-hit moves calc with 3 hits always, loaded dice with 4. 

## **Discord contact info**
MaximeGr
