### PR TITLE
form change npc

### DIFF
--- a/data/maps/Route121_SafariZoneEntrance/map.json
+++ b/data/maps/Route121_SafariZoneEntrance/map.json
@@ -52,6 +52,19 @@
       "trainer_sight_or_berry_tree_id": "0",
       "script": "0x0",
       "flag": "0"
+    },
+    {
+      "graphics_id": "OBJ_EVENT_GFX_MANIAC",
+      "x": 17,
+      "y": 2,
+      "elevation": 0,
+      "movement_type": "MOVEMENT_TYPE_FACE_LEFT",
+      "movement_range_x": 0,
+      "movement_range_y": 0,
+      "trainer_type": "TRAINER_TYPE_NONE",
+      "trainer_sight_or_berry_tree_id": "0",
+      "script": "Route121_SafariZoneEntrance_EventScript_Maniac",
+      "flag": "0"
     }
   ],
   "warp_events": [

--- a/data/maps/Route121_SafariZoneEntrance/scripts.inc
+++ b/data/maps/Route121_SafariZoneEntrance/scripts.inc
@@ -260,3 +260,2211 @@ Route121_SafariZoneEntrance_EventScript_TrainerTipSign::
 	msgbox Route121_SafariZoneEntrance_Text_TrainerTip, MSGBOX_SIGN
 # 131 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	end
+
+Route121_SafariZoneEntrance_EventScript_Maniac::
+# 136 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	lock
+# 137 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	faceplayer
+# 138 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto_if_set FLAG_TEMP_1, Route121_SafariZoneEntrance_EventScript_ManiacAskAgain
+# 139 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_EventScript_ManiacWannaChangeForm, MSGBOX_YESNO
+# 140 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	call_if_eq VAR_RESULT, YES, Route121_SafariZoneEntrance_EventScript_ManiacAccept
+# 141 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto_if_eq VAR_RESULT, NO, Route121_SafariZoneEntrance_EventScript_ManiacDecline
+# 142 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacAskAgain::
+# 147 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Maniac_AskAgain, MSGBOX_YESNO
+# 148 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeForm
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeForm::
+# 153 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	call_if_eq VAR_RESULT, YES, Route121_SafariZoneEntrance_EventScript_ManiacAccept
+# 154 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto_if_eq VAR_RESULT, NO, Route121_SafariZoneEntrance_EventScript_ManiacDecline
+# 155 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept::
+# 160 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChoosePartyMon
+# 161 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 162 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	copyvar VAR_0x800A, VAR_0x8004
+# 163 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, Route121_SafariZoneEntrance_EventScript_ManiacDecline
+# 164 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	specialvar VAR_RESULT, ScriptGetPartyMonSpecies
+# 165 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 166 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GASTRODON, Route121_SafariZoneEntrance_EventScript_ManiacAccept_2
+# 167 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GASTRODON_EAST, Route121_SafariZoneEntrance_EventScript_ManiacAccept_2
+# 168 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GASTRODON_WEST, Route121_SafariZoneEntrance_EventScript_ManiacAccept_2
+# 170 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SAWSBUCK, Route121_SafariZoneEntrance_EventScript_ManiacAccept_3
+# 171 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SAWSBUCK_SPRING, Route121_SafariZoneEntrance_EventScript_ManiacAccept_3
+# 172 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SAWSBUCK_SUMMER, Route121_SafariZoneEntrance_EventScript_ManiacAccept_3
+# 173 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SAWSBUCK_AUTUMN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_3
+# 174 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SAWSBUCK_WINTER, Route121_SafariZoneEntrance_EventScript_ManiacAccept_3
+# 176 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_KELDEO, Route121_SafariZoneEntrance_EventScript_ManiacAccept_4
+# 177 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_KELDEO_ORDINARY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_4
+# 178 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_KELDEO_RESOLUTE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_4
+# 180 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 181 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_ICY_SNOW, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 182 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_POLAR, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 183 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_TUNDRA, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 184 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_CONTINENTAL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 185 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_GARDEN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 186 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_ELEGANT, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 187 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_MEADOW, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 188 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_MODERN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 189 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_MARINE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 190 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_ARCHIPELAGO, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 191 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_HIGH_PLAINS, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 192 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_SANDSTORM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 193 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_RIVER, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 194 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_MONSOON, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 195 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_SAVANNA, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 196 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_SUN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 197 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_OCEAN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 198 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_JUNGLE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 199 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_FANCY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 200 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_VIVILLON_POKEBALL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_5
+# 202 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FLORGES, Route121_SafariZoneEntrance_EventScript_ManiacAccept_6
+# 203 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FLORGES_RED, Route121_SafariZoneEntrance_EventScript_ManiacAccept_6
+# 204 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FLORGES_YELLOW, Route121_SafariZoneEntrance_EventScript_ManiacAccept_6
+# 205 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FLORGES_ORANGE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_6
+# 206 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FLORGES_BLUE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_6
+# 207 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FLORGES_WHITE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_6
+# 209 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 210 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_NATURAL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 211 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_HEART_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 212 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_STAR_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 213 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_DIAMOND_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 214 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_DEBUTANTE_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 215 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_MATRON_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 216 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_DANDY_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 217 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_LA_REINE_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 218 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_KABUKI_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 219 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_FURFROU_PHARAOH_TRIM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_7
+# 221 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GOURGEIST, Route121_SafariZoneEntrance_EventScript_ManiacAccept_8
+# 222 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GOURGEIST_AVERAGE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_8
+# 223 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GOURGEIST_SMALL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_8
+# 224 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GOURGEIST_LARGE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_8
+# 225 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_GOURGEIST_SUPER, Route121_SafariZoneEntrance_EventScript_ManiacAccept_8
+# 227 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 228 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 229 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_RED, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 230 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_ORANGE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 231 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_YELLOW, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 232 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_GREEN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 233 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_BLUE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 234 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_INDIGO, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 235 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_VIOLET, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 236 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR_RED, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 237 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR_ORANGE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 238 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR_YELLOW, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 239 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR_GREEN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 240 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR_BLUE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 241 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR_INDIGO, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 242 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_METEOR_VIOLET, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 243 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 244 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE_RED, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 245 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE_ORANGE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 246 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE_YELLOW, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 247 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE_GREEN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 248 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE_BLUE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 249 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE_INDIGO, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 250 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MINIOR_CORE_VIOLET, Route121_SafariZoneEntrance_EventScript_ManiacAccept_9
+# 252 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MAGEARNA, Route121_SafariZoneEntrance_EventScript_ManiacAccept_10
+# 253 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MAGEARNA_ORIGINAL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_10
+# 255 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_TOXTRICITY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_11
+# 256 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_TOXTRICITY_AMPED, Route121_SafariZoneEntrance_EventScript_ManiacAccept_11
+# 257 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_TOXTRICITY_LOW_KEY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_11
+# 259 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_POLTEAGEIST, Route121_SafariZoneEntrance_EventScript_ManiacAccept_12
+# 260 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_POLTEAGEIST_PHONY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_12
+# 261 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_POLTEAGEIST_ANTIQUE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_12
+# 263 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 264 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STRAWBERRY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 265 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 266 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STRAWBERRY_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 267 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RUBY_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 268 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_MATCHA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 269 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_MINT_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 270 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LEMON_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 271 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_SALTED_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 272 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RUBY_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 273 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CARAMEL_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 274 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RAINBOW_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 275 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 276 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 277 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_RUBY_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 278 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_MATCHA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 279 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_MINT_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 280 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_LEMON_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 281 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_SALTED_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 282 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_RUBY_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 283 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_CARAMEL_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 284 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_BERRY_RAINBOW_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 285 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 286 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 287 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_RUBY_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 288 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_MATCHA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 289 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_MINT_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 290 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_LEMON_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 291 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_SALTED_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 292 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_RUBY_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 293 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_CARAMEL_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 294 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_LOVE_RAINBOW_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 295 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 296 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 297 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_RUBY_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 298 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_MATCHA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 299 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_MINT_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 300 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_LEMON_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 301 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_SALTED_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 302 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_RUBY_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 303 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_CARAMEL_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 304 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_STAR_RAINBOW_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 305 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 306 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 307 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_RUBY_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 308 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_MATCHA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 309 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_MINT_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 310 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_LEMON_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 311 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_SALTED_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 312 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_RUBY_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 313 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_CARAMEL_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 314 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_CLOVER_RAINBOW_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 315 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 316 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 317 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_RUBY_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 318 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_MATCHA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 319 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_MINT_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 320 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_LEMON_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 321 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_SALTED_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 322 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_RUBY_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 323 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_CARAMEL_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 324 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_FLOWER_RAINBOW_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 325 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 326 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_VANILLA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 327 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_RUBY_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 328 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_MATCHA_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 329 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_MINT_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 330 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_LEMON_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 331 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_SALTED_CREAM, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 332 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_RUBY_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 333 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_CARAMEL_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 334 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ALCREMIE_RIBBON_RAINBOW_SWIRL, Route121_SafariZoneEntrance_EventScript_ManiacAccept_13
+# 336 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ZARUDE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_14
+# 337 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_ZARUDE_DADA, Route121_SafariZoneEntrance_EventScript_ManiacAccept_14
+# 339 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MAUSHOLD, Route121_SafariZoneEntrance_EventScript_ManiacAccept_15
+# 340 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MAUSHOLD_THREE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_15
+# 341 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_MAUSHOLD_FOUR, Route121_SafariZoneEntrance_EventScript_ManiacAccept_15
+# 343 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SQUAWKABILLY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_16
+# 344 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SQUAWKABILLY_GREEN, Route121_SafariZoneEntrance_EventScript_ManiacAccept_16
+# 345 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SQUAWKABILLY_BLUE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_16
+# 346 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SQUAWKABILLY_YELLOW, Route121_SafariZoneEntrance_EventScript_ManiacAccept_16
+# 347 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SQUAWKABILLY_WHITE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_16
+# 349 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_TATSUGIRI, Route121_SafariZoneEntrance_EventScript_ManiacAccept_17
+# 350 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_TATSUGIRI_CURLY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_17
+# 351 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_TATSUGIRI_DROOPY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_17
+# 352 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_TATSUGIRI_STRETCHY, Route121_SafariZoneEntrance_EventScript_ManiacAccept_17
+# 354 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_DUDUNSPARCE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_18
+# 355 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_DUDUNSPARCE_TWO_SEGMENT, Route121_SafariZoneEntrance_EventScript_ManiacAccept_18
+# 356 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_DUDUNSPARCE_THREE_SEGMENT, Route121_SafariZoneEntrance_EventScript_ManiacAccept_18
+# 358 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SINISTCHA, Route121_SafariZoneEntrance_EventScript_ManiacAccept_19
+# 359 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SINISTCHA_UNREMARKABLE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_19
+# 360 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case SPECIES_SINISTCHA_MASTERPIECE, Route121_SafariZoneEntrance_EventScript_ManiacAccept_19
+# 363 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_ThisIsntAMon, MSGBOX_DEFAULT
+# 364 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_2:
+# 169 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_3:
+# 175 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_4:
+# 179 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_5:
+# 201 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_6:
+# 208 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_7:
+# 220 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_8:
+# 226 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_9:
+# 251 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_10:
+# 254 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_11:
+# 258 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_12:
+# 262 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_13:
+# 335 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_14:
+# 338 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_15:
+# 342 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_16:
+# 348 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_17:
+# 353 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_18:
+# 357 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm
+	return
+
+Route121_SafariZoneEntrance_EventScript_ManiacAccept_19:
+# 361 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm
+	return
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacDecline::
+# 370 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setflag FLAG_TEMP_1
+# 371 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Maniac_ComeBackWithOne, MSGBOX_DEFAULT
+# 372 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm::
+# 378 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 379 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 380 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_GASTRODON_FORM
+# 381 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 382 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 383 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 384 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_3
+# 386 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_4
+# 388 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_1:
+# 391 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 392 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_3:
+# 385 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonEast
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_4:
+# 387 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonWest
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_5:
+# 389 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonEast::
+# 397 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GASTRODON_EAST
+# 398 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 399 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 400 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonWest::
+# 405 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GASTRODON_WEST
+# 406 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 407 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 408 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm::
+# 413 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 414 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 415 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SAWSBUCK_FORM
+# 416 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 417 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 418 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 419 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_3
+# 421 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_4
+# 423 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_5
+# 425 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_6
+# 427 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_7
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1:
+# 430 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 431 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_3:
+# 420 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_4:
+# 422 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_5:
+# 424 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_6:
+# 426 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckWinter
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_7:
+# 428 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring::
+# 436 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SAWSBUCK_SPRING
+# 437 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 438 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 439 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer::
+# 444 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SAWSBUCK_SUMMER
+# 445 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 446 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 447 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn::
+# 452 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SAWSBUCK_AUTUMN
+# 453 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 454 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 455 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckWinter::
+# 460 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SAWSBUCK_WINTER
+# 461 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 462 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 463 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm::
+# 468 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 469 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 470 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_KELDEO_FORM
+# 471 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 472 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 473 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 474 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_3
+# 476 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_4
+# 478 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1:
+# 481 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 482 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_3:
+# 475 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_4:
+# 477 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoResolute
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_5:
+# 479 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary::
+# 487 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_KELDEO_ORDINARY
+# 488 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 489 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 490 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoResolute::
+# 495 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_KELDEO_RESOLUTE
+# 496 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 497 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 498 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm::
+# 503 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 504 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 505 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_VIVILLON_FORM
+# 506 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 507 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 508 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 509 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_3
+# 511 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_4
+# 513 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1:
+# 516 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 517 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_3:
+# 510 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_4:
+# 512 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonPokeball
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_5:
+# 514 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy::
+# 522 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_VIVILLON_FANCY
+# 523 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 524 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 525 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonPokeball::
+# 530 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_VIVILLON_POKEBALL
+# 531 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 532 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 533 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm::
+# 538 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 539 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 540 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_FLORGES_FORM
+# 541 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 542 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 543 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 544 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_3
+# 546 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_4
+# 548 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_5
+# 550 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_6
+# 552 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_7
+# 554 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_8
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1:
+# 557 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 558 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_3:
+# 545 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_4:
+# 547 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_5:
+# 549 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_6:
+# 551 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_7:
+# 553 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesWhite
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_8:
+# 555 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed::
+# 563 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FLORGES_RED
+# 564 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 565 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 566 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow::
+# 571 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FLORGES_YELLOW
+# 572 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 573 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 574 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange::
+# 579 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FLORGES_ORANGE
+# 580 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 581 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 582 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue::
+# 587 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FLORGES_BLUE
+# 588 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 589 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 590 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesWhite::
+# 595 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FLORGES_WHITE
+# 596 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 597 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 598 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm::
+# 603 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 604 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 605 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_FURFROU_FORM
+# 606 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 607 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 608 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 609 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_3
+# 611 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_4
+# 613 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_5
+# 615 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_6
+# 617 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_7
+# 619 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 5, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_8
+# 621 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 6, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_9
+# 623 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 7, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_10
+# 625 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 8, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_11
+# 627 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 9, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_12
+# 629 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_13
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1:
+# 632 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 633 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_3:
+# 610 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_4:
+# 612 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_5:
+# 614 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_6:
+# 616 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_7:
+# 618 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_8:
+# 620 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_9:
+# 622 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_10:
+# 624 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_11:
+# 626 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_12:
+# 628 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouPharaoh
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_13:
+# 630 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural::
+# 638 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_NATURAL
+# 639 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 640 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 641 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart::
+# 646 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_HEART_TRIM
+# 647 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 648 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 649 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar::
+# 654 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_STAR_TRIM
+# 655 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 656 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 657 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond::
+# 662 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_DIAMOND_TRIM
+# 663 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 664 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 665 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante::
+# 670 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_DEBUTANTE_TRIM
+# 671 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 672 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 673 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron::
+# 678 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_MATRON_TRIM
+# 679 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 680 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 681 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy::
+# 686 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_DANDY_TRIM
+# 687 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 688 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 689 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine::
+# 694 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_LA_REINE_TRIM
+# 695 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 696 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 697 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki::
+# 702 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_KABUKI_TRIM
+# 703 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 704 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 705 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouPharaoh::
+# 710 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_PHARAOH_TRIM
+# 711 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 712 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 713 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm::
+# 718 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 719 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 720 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_GOURGEIST_FORM
+# 721 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 722 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 723 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 724 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_3
+# 726 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_4
+# 728 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_5
+# 730 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_6
+# 732 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_7
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1:
+# 735 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 736 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_3:
+# 725 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_4:
+# 727 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_5:
+# 729 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_6:
+# 731 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_7:
+# 733 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage::
+# 741 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_AVERAGE
+# 742 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 743 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 744 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall::
+# 749 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_SMALL
+# 750 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 751 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 752 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge::
+# 757 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_LARGE
+# 758 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 759 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 760 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper::
+# 765 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_SUPER
+# 766 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 767 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 768 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm::
+# 773 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 774 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 775 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_MINIOR_FORM
+# 776 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 777 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 778 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 779 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_3
+# 781 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_4
+# 783 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_5
+# 785 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_6
+# 787 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_7
+# 789 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 5, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_8
+# 791 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 6, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_9
+# 793 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_10
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1:
+# 796 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 797 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_3:
+# 780 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_4:
+# 782 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_5:
+# 784 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_6:
+# 786 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_7:
+# 788 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_8:
+# 790 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_9:
+# 792 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_10:
+# 794 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange::
+# 802 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MINIOR_ORANGE
+# 803 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 804 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 805 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed::
+# 810 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MINIOR_RED
+# 811 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 812 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 813 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow::
+# 818 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MINIOR_YELLOW
+# 819 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 820 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 821 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen::
+# 826 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MINIOR_GREEN
+# 827 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 828 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 829 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue::
+# 834 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MINIOR_BLUE
+# 835 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 836 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 837 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo::
+# 842 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MINIOR_INDIGO
+# 843 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 844 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 845 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet::
+# 850 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MINIOR_VIOLET
+# 851 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 852 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 853 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm::
+# 858 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 859 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 860 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_MAGEARNA_FORM
+# 861 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 862 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 863 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 864 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_3
+# 866 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_4
+# 868 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1:
+# 871 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 872 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_3:
+# 865 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_4:
+# 867 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_5:
+# 869 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna::
+# 877 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MAGEARNA
+# 878 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 879 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 880 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal::
+# 885 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MAGEARNA_ORIGINAL
+# 886 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 887 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 888 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm::
+# 893 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 894 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 895 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_TOXTRICITY_FORM
+# 896 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 897 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 898 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 899 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_3
+# 901 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_4
+# 903 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1:
+# 906 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 907 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_3:
+# 900 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_4:
+# 902 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityLowKey
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_5:
+# 904 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped::
+# 912 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_TOXTRICITY_AMPED
+# 913 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 914 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 915 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityLowKey::
+# 920 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_TOXTRICITY_LOW_KEY
+# 921 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 922 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 923 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm::
+# 928 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 929 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 930 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_POLTEAGEIST_FORM
+# 931 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 932 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 933 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 934 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_3
+# 936 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_4
+# 938 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1:
+# 941 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 942 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_3:
+# 935 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_4:
+# 937 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistAntique
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_5:
+# 939 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony::
+# 947 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_POLTEAGEIST_PHONY
+# 948 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 949 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 950 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistAntique::
+# 955 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_POLTEAGEIST_ANTIQUE
+# 956 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 957 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 958 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm::
+# 963 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 964 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 965 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_ALCREMIE_FORM
+# 966 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 967 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 968 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 969 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_3
+# 971 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_4
+# 973 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_5
+# 975 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_6
+Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1:
+# 978 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 979 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_3:
+# 970 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_4:
+# 972 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_5:
+# 974 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieStrawberry
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_6:
+# 976 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry::
+# 984 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_ALCREMIE_BERRY
+# 985 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 986 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 987 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla::
+# 992 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_ALCREMIE_VANILLA_CREAM
+# 993 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 994 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 995 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieStrawberry::
+# 1000 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_ALCREMIE_STRAWBERRY_VANILLA_CREAM
+# 1001 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1002 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1003 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm::
+# 1008 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1009 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1010 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_ZARUDE_FORM
+# 1011 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1012 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1013 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1014 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_3
+# 1016 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_4
+# 1018 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1:
+# 1021 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1022 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_3:
+# 1015 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_4:
+# 1017 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeZarudeDada
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_5:
+# 1019 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude::
+# 1027 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_ZARUDE
+# 1028 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1029 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1030 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeZarudeDada::
+# 1035 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_ZARUDE_DADA
+# 1036 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1037 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1038 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm::
+# 1043 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1044 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1045 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_MAUSHOLD_FORM
+# 1046 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1047 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1048 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1049 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_3
+# 1051 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_4
+# 1053 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1:
+# 1056 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1057 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_3:
+# 1050 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_4:
+# 1052 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdFour
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_5:
+# 1054 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree::
+# 1062 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MAUSHOLD_THREE
+# 1063 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1064 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1065 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdFour::
+# 1070 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MAUSHOLD_FOUR
+# 1071 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1072 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1073 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm::
+# 1078 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1079 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1080 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SQUAWKABILLY_FORM
+# 1081 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1082 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1083 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1084 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_3
+# 1086 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_4
+# 1088 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_5
+# 1090 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_6
+# 1092 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_7
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1:
+# 1095 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1096 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_3:
+# 1085 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_4:
+# 1087 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_5:
+# 1089 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_6:
+# 1091 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyWhite
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_7:
+# 1093 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen::
+# 1101 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_GREEN
+# 1102 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1103 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1104 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue::
+# 1109 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_BLUE
+# 1110 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1111 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1112 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow::
+# 1117 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_YELLOW
+# 1118 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1119 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1120 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyWhite::
+# 1125 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_WHITE
+# 1126 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1127 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1128 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm::
+# 1133 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1134 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1135 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_TATSUGIRI_FORM
+# 1136 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1137 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1138 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1139 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_3
+# 1141 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_4
+# 1143 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_5
+# 1145 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_6
+Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1:
+# 1148 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1149 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_3:
+# 1140 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_4:
+# 1142 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_5:
+# 1144 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_6:
+# 1146 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly::
+# 1154 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_TATSUGIRI_CURLY
+# 1155 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1156 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1157 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy::
+# 1162 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_TATSUGIRI_DROOPY
+# 1163 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1164 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1165 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy::
+# 1170 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_TATSUGIRI_STRETCHY
+# 1171 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1172 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1173 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm::
+# 1178 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1179 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1180 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_DUDUNSPARCE_FORM
+# 1181 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1182 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1183 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1184 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_3
+# 1186 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_4
+# 1188 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1:
+# 1191 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1192 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_3:
+# 1185 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_4:
+# 1187 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_5:
+# 1189 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo::
+# 1197 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_DUDUNSPARCE_TWO_SEGMENT
+# 1198 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1199 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1200 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree::
+# 1205 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_DUDUNSPARCE_THREE_SEGMENT
+# 1206 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1207 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1208 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm::
+# 1213 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1214 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1215 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SINISTCHA_FORM
+# 1216 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1217 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1218 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1219 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_3
+# 1221 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_4
+# 1223 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1:
+# 1226 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1227 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_3:
+# 1220 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_4:
+# 1222 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaMasterpiece
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_5:
+# 1224 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable::
+# 1232 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SINISTCHA_UNREMARKABLE
+# 1233 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1234 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1235 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaMasterpiece::
+# 1240 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_SINISTCHA_MASTERPIECE
+# 1241 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1242 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1243 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange::
+# 1248 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	fadescreen FADE_TO_BLACK
+# 1249 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	delay 16
+# 1250 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	fadescreen FADE_FROM_BLACK
+# 1251 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhatASpecimen, MSGBOX_DEFAULT
+# 1252 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacWannaChangeForm::
+# 1256 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	.string "This place is incredible, they have all\n"
+	.string "kinds of species cohabiting. This is\l"
+	.string "the 53rd day in a row I come to visit\l"
+	.string "and I still discover new things!\p"
+	.string "Recently, I've been really interested\n"
+	.string "in Pokémon that can have different\l"
+	.string "forms in the wild.\p"
+	.string "Do you have such a specimen you'd let\n"
+	.string "me analyze?$"
+
+Maniac_AskAgain::
+# 1268 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	.string "So, which one should I analyze?$"
+
+Maniac_ComeBackWithOne::
+# 1272 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	.string "You could have just said you didn't\n"
+	.string "want to share…$"
+
+Route121_SafariZoneEntrance_Text_WhatASpecimen::
+# 1277 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	.string "I'm done! Thank you so much for giving me\n"
+	.string "this opportunity. I'm so lucky to have\l"
+	.string "met you. Please come back anytime with\l"
+	.string "other ones. Aren't Pokémon amazing?!$"
+
+Route121_SafariZoneEntrance_Text_WhichForm::
+# 1284 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	.string "Fascinating! Would you like me to change\n"
+	.string "its form?$"
+
+Route121_SafariZoneEntrance_Text_ThisIsntAMon::
+# 1289 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	.string "What are you, some kind of amateur?\n"
+	.string "This Pokémon can't change forms.$"

--- a/data/maps/Route121_SafariZoneEntrance/scripts.inc
+++ b/data/maps/Route121_SafariZoneEntrance/scripts.inc
@@ -794,8 +794,10 @@ Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm::
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_5
 Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_1:
 # 391 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+	closemessage
 # 392 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 393 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
@@ -816,357 +818,363 @@ Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm_5:
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonEast::
-# 397 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_GASTRODON_EAST
 # 398 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
+	setvar VAR_0x8009, SPECIES_GASTRODON_EAST
 # 399 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+	special ChangePartyMonForm
 # 400 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 401 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 402 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonWest::
-# 405 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_GASTRODON_WEST
-# 406 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
 # 407 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+	setvar VAR_0x8009, SPECIES_GASTRODON_WEST
 # 408 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 409 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 410 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 411 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm::
-# 413 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 414 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 415 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SAWSBUCK_FORM
 # 416 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
 # 417 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
+	waitmessage
 # 418 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SAWSBUCK_FORM
 # 419 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_3
+	special ShowScrollableMultichoice
+# 420 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
 # 421 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 422 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_3
+# 424 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_4
-# 423 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 426 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_5
-# 425 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 428 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_6
-# 427 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 430 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_7
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1:
-# 430 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 433 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 434 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 431 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 435 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_3:
-# 420 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 423 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_4:
-# 422 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 425 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_5:
-# 424 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 427 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_6:
-# 426 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 429 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckWinter
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_7:
-# 428 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 431 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring::
-# 436 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 440 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SAWSBUCK_SPRING
-# 437 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 441 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 438 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 442 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 443 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 439 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 444 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer::
-# 444 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 449 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SAWSBUCK_SUMMER
-# 445 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 450 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 446 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 451 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 452 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 447 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 453 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn::
-# 452 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 458 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SAWSBUCK_AUTUMN
-# 453 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 459 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 454 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 460 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 461 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 455 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 462 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckWinter::
-# 460 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 467 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SAWSBUCK_WINTER
-# 461 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 468 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 462 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 469 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 470 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 463 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 471 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm::
-# 468 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 469 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 470 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_KELDEO_FORM
-# 471 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
-# 472 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 473 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 474 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_3
 # 476 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_4
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 477 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
 # 478 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_KELDEO_FORM
+# 479 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 480 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 481 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 482 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_3
+# 484 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_4
+# 486 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_5
 Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1:
-# 481 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 489 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 490 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 482 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 491 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_3:
-# 475 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 483 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_4:
-# 477 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 485 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoResolute
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_5:
-# 479 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 487 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary::
-# 487 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 496 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_KELDEO_ORDINARY
-# 488 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 497 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 489 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 498 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 499 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 490 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 500 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoResolute::
-# 495 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 505 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_KELDEO_RESOLUTE
-# 496 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 506 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 497 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 507 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 508 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 498 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 509 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm::
-# 503 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 514 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 504 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 515 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 505 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 516 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_VIVILLON_FORM
-# 506 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 517 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 507 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 518 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 508 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 519 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 509 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 520 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_3
-# 511 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 522 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_4
-# 513 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 524 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_5
 Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1:
-# 516 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 527 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 528 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 517 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 529 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_3:
-# 510 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 521 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_4:
-# 512 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 523 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonPokeball
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_5:
-# 514 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 525 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy::
-# 522 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 534 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_VIVILLON_FANCY
-# 523 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 535 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 524 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 536 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 537 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 525 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 538 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonPokeball::
-# 530 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 543 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_VIVILLON_POKEBALL
-# 531 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 544 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 532 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 545 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 546 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 533 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 547 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm::
-# 538 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 539 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 540 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_FLORGES_FORM
-# 541 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
-# 542 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 543 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 544 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_3
-# 546 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_4
-# 548 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_5
-# 550 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_6
 # 552 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_7
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 553 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
 # 554 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_FLORGES_FORM
+# 555 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 556 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 557 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 558 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_3
+# 560 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_4
+# 562 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_5
+# 564 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_6
+# 566 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_7
+# 568 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_8
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1:
-# 557 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 571 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 572 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 558 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 573 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_3:
-# 545 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 559 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_4:
-# 547 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 561 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_5:
-# 549 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 563 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_6:
-# 551 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 565 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_7:
-# 553 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 567 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesWhite
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_8:
-# 555 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 569 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed::
-# 563 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 578 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FLORGES_RED
-# 564 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 565 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 566 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow::
-# 571 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_FLORGES_YELLOW
-# 572 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 573 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 574 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange::
 # 579 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_FLORGES_ORANGE
-# 580 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
+# 580 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
 # 581 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
 # 582 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
@@ -1174,193 +1182,197 @@ Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange::
 	end
 
 
-Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue::
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow::
 # 587 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_FLORGES_BLUE
+	setvar VAR_0x8009, SPECIES_FLORGES_YELLOW
 # 588 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
 # 589 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+	closemessage
 # 590 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 591 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange::
+# 596 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FLORGES_ORANGE
+# 597 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 598 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 599 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 600 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue::
+# 605 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FLORGES_BLUE
+# 606 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 607 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 608 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 609 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesWhite::
-# 595 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 614 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FLORGES_WHITE
-# 596 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 615 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 597 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 616 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 617 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 598 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 618 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm::
-# 603 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 604 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 605 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_FURFROU_FORM
-# 606 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
-# 607 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 608 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 609 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_3
-# 611 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_4
-# 613 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_5
-# 615 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_6
-# 617 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_7
-# 619 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 5, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_8
-# 621 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 6, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_9
 # 623 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 7, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_10
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 624 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
 # 625 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 8, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_11
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_FURFROU_FORM
+# 626 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
 # 627 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 9, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_12
+	waitstate
+# 628 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
 # 629 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_3
+# 631 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_4
+# 633 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_5
+# 635 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_6
+# 637 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_7
+# 639 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 5, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_8
+# 641 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 6, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_9
+# 643 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 7, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_10
+# 645 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 8, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_11
+# 647 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 9, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_12
+# 649 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_13
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1:
-# 632 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 652 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 653 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 633 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 654 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_3:
-# 610 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 630 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_4:
-# 612 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 632 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_5:
-# 614 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 634 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_6:
-# 616 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 636 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_7:
-# 618 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 638 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_8:
-# 620 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 640 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_9:
-# 622 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 642 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_10:
-# 624 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 644 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_11:
-# 626 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 646 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_12:
-# 628 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 648 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouPharaoh
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_13:
-# 630 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 650 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural::
-# 638 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 659 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FURFROU_NATURAL
-# 639 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 660 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 640 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 661 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 662 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 641 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 663 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart::
-# 646 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 668 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FURFROU_HEART_TRIM
-# 647 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 669 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 648 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 670 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 671 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 649 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 672 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar::
-# 654 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 677 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FURFROU_STAR_TRIM
-# 655 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 656 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 657 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond::
-# 662 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_FURFROU_DIAMOND_TRIM
-# 663 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 664 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 665 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante::
-# 670 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_FURFROU_DEBUTANTE_TRIM
-# 671 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 672 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 673 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron::
 # 678 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_FURFROU_MATRON_TRIM
-# 679 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
+# 679 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
 # 680 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
 # 681 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
@@ -1368,115 +1380,97 @@ Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron::
 	end
 
 
-Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy::
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond::
 # 686 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_FURFROU_DANDY_TRIM
+	setvar VAR_0x8009, SPECIES_FURFROU_DIAMOND_TRIM
 # 687 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
 # 688 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+	closemessage
 # 689 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 690 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante::
+# 695 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_DEBUTANTE_TRIM
+# 696 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 697 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 698 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 699 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron::
+# 704 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_MATRON_TRIM
+# 705 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 706 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 707 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 708 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy::
+# 713 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_FURFROU_DANDY_TRIM
+# 714 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 715 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 716 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 717 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine::
-# 694 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 722 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FURFROU_LA_REINE_TRIM
-# 695 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 723 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 696 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 724 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 725 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 697 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 726 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki::
-# 702 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 731 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FURFROU_KABUKI_TRIM
-# 703 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 732 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 704 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 733 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 734 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 705 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 735 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouPharaoh::
-# 710 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 740 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_FURFROU_PHARAOH_TRIM
-# 711 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 712 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 713 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm::
-# 718 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 719 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 720 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_GOURGEIST_FORM
-# 721 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
-# 722 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 723 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 724 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_3
-# 726 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_4
-# 728 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_5
-# 730 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_6
-# 732 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_7
-Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1:
-# 735 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 736 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_3:
-# 725 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_4:
-# 727 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_5:
-# 729 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_6:
-# 731 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_7:
-# 733 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage::
 # 741 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_GOURGEIST_AVERAGE
-# 742 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
+# 742 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
 # 743 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
 # 744 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
@@ -1484,262 +1478,276 @@ Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage::
 	end
 
 
-Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall::
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm::
 # 749 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_GOURGEIST_SMALL
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
 # 750 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
+	waitmessage
 # 751 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_GOURGEIST_FORM
 # 752 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge::
+	special ShowScrollableMultichoice
+# 753 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 754 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 755 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_3
 # 757 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_GOURGEIST_LARGE
-# 758 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_4
 # 759 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 760 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper::
-# 765 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_GOURGEIST_SUPER
+	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_5
+# 761 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_6
+# 763 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_7
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1:
 # 766 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
+	closemessage
 # 767 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
 # 768 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_3:
+# 756 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_4:
+# 758 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_5:
+# 760 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_6:
+# 762 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_7:
+# 764 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage::
+# 773 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_AVERAGE
+# 774 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 775 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 776 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 777 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall::
+# 782 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_SMALL
+# 783 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 784 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 785 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 786 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge::
+# 791 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_LARGE
+# 792 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 793 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 794 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 795 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper::
+# 800 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_GOURGEIST_SUPER
+# 801 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 802 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 803 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 804 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm::
-# 773 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 809 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 774 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 810 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 775 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 811 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_MINIOR_FORM
-# 776 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 812 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 777 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 813 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 778 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 814 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 779 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 815 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_3
-# 781 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 817 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_4
-# 783 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 819 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_5
-# 785 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 821 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_6
-# 787 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 823 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 4, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_7
-# 789 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 825 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 5, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_8
-# 791 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 827 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 6, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_9
-# 793 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 829 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_10
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1:
-# 796 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 832 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 833 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 797 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 834 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_3:
-# 780 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 816 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_4:
-# 782 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 818 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_5:
-# 784 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 820 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_6:
-# 786 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 822 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_7:
-# 788 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 824 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_8:
-# 790 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 826 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_9:
-# 792 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 828 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_10:
-# 794 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 830 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange::
-# 802 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 839 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MINIOR_ORANGE
-# 803 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 840 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 804 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 841 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 842 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 805 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 843 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed::
-# 810 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 848 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MINIOR_RED
-# 811 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 849 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 812 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 850 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 851 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 813 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 852 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow::
-# 818 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 857 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MINIOR_YELLOW
-# 819 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 858 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 820 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 859 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 860 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 821 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 861 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen::
-# 826 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 866 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MINIOR_GREEN
-# 827 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 867 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 828 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 868 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 869 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 829 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 870 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue::
-# 834 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 875 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MINIOR_BLUE
-# 835 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 876 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 836 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 877 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 878 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 837 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 879 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo::
-# 842 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 884 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MINIOR_INDIGO
-# 843 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 844 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 845 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet::
-# 850 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_MINIOR_VIOLET
-# 851 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 852 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 853 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm::
-# 858 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 859 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 860 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_MAGEARNA_FORM
-# 861 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
-# 862 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 863 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 864 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_3
-# 866 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_4
-# 868 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_5
-Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1:
-# 871 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 872 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_3:
-# 865 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_4:
-# 867 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_5:
-# 869 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna::
-# 877 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_MAGEARNA
-# 878 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 879 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 880 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal::
 # 885 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_MAGEARNA_ORIGINAL
-# 886 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
+# 886 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
 # 887 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
 # 888 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
@@ -1747,692 +1755,840 @@ Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal::
 	end
 
 
-Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm::
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet::
 # 893 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+	setvar VAR_0x8009, SPECIES_MINIOR_VIOLET
 # 894 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
+	special ChangePartyMonForm
 # 895 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_TOXTRICITY_FORM
+	closemessage
 # 896 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
 # 897 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 898 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 899 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_3
-# 901 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_4
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm::
+# 902 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
 # 903 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 904 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_MAGEARNA_FORM
+# 905 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 906 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 907 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 908 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_3
+# 910 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_4
+# 912 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1:
+# 915 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 916 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 917 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_3:
+# 909 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_4:
+# 911 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_5:
+# 913 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna::
+# 922 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MAGEARNA
+# 923 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 924 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 925 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 926 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal::
+# 931 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_MAGEARNA_ORIGINAL
+# 932 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 933 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 934 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 935 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm::
+# 940 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 941 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 942 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_TOXTRICITY_FORM
+# 943 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 944 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 945 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 946 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_3
+# 948 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_4
+# 950 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_5
 Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1:
-# 906 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 953 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 954 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 907 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 955 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_3:
-# 900 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 947 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_4:
-# 902 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 949 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityLowKey
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_5:
-# 904 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 951 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped::
-# 912 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 960 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_TOXTRICITY_AMPED
-# 913 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 961 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 914 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 962 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 963 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 915 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 964 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityLowKey::
-# 920 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 969 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_TOXTRICITY_LOW_KEY
-# 921 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 970 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 922 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 971 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 972 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 923 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 973 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm::
-# 928 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 978 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 929 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 979 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 930 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 980 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_POLTEAGEIST_FORM
-# 931 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 981 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 932 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 982 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 933 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 983 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 934 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 984 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_3
-# 936 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 986 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_4
-# 938 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 988 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_5
 Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1:
-# 941 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 991 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 992 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 942 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 993 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_3:
-# 935 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 985 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_4:
-# 937 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 987 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistAntique
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_5:
-# 939 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 989 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony::
-# 947 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 998 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_POLTEAGEIST_PHONY
-# 948 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 999 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 949 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1000 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1001 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 950 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1002 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistAntique::
-# 955 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1007 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_POLTEAGEIST_ANTIQUE
-# 956 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1008 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 957 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1009 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1010 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 958 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1011 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm::
-# 963 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1016 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 964 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1017 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 965 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1018 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_ALCREMIE_FORM
-# 966 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1019 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 967 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1020 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 968 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1021 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 969 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1022 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_3
-# 971 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1024 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_4
-# 973 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1026 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_5
-# 975 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1028 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_6
 Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1:
-# 978 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1031 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1032 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 979 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1033 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_3:
-# 970 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1023 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_4:
-# 972 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1025 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_5:
-# 974 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1027 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieStrawberry
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_6:
-# 976 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1029 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry::
-# 984 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1038 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_ALCREMIE_BERRY
-# 985 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1039 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 986 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1040 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1041 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 987 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1042 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla::
-# 992 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1047 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_ALCREMIE_VANILLA_CREAM
-# 993 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1048 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 994 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1049 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1050 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 995 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1051 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieStrawberry::
-# 1000 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1056 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_ALCREMIE_STRAWBERRY_VANILLA_CREAM
-# 1001 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1057 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1002 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1058 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1059 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1003 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1060 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm::
-# 1008 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1065 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 1009 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1066 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 1010 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1067 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_ZARUDE_FORM
-# 1011 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1068 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 1012 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1069 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 1013 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1070 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 1014 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1071 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_3
-# 1016 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1073 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_4
-# 1018 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1075 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_5
 Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1:
-# 1021 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1078 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1079 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1022 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1080 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_3:
-# 1015 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1072 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_4:
-# 1017 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1074 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeZarudeDada
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_5:
-# 1019 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1076 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude::
-# 1027 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1085 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_ZARUDE
-# 1028 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1086 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1029 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1087 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1088 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1030 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1089 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeZarudeDada::
-# 1035 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1094 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_ZARUDE_DADA
-# 1036 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1095 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1037 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1096 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1097 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1038 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1098 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm::
-# 1043 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1103 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 1044 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1104 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 1045 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1105 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_MAUSHOLD_FORM
-# 1046 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1106 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 1047 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1107 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 1048 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1108 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 1049 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1109 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_3
-# 1051 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1111 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_4
-# 1053 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1113 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_5
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1:
-# 1056 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1116 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1117 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1057 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1118 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_3:
-# 1050 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1110 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_4:
-# 1052 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1112 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdFour
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_5:
-# 1054 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1114 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree::
-# 1062 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1123 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MAUSHOLD_THREE
-# 1063 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1124 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1064 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1125 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1126 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1065 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1127 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdFour::
-# 1070 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1132 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_MAUSHOLD_FOUR
-# 1071 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1133 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1072 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1134 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1135 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1073 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1136 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm::
-# 1078 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1141 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 1079 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1142 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 1080 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1143 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SQUAWKABILLY_FORM
-# 1081 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1144 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 1082 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1145 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 1083 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1146 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 1084 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1147 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_3
-# 1086 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1149 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_4
-# 1088 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1151 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_5
-# 1090 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1153 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 3, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_6
-# 1092 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1155 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_7
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1:
-# 1095 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1158 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1159 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1096 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1160 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_3:
-# 1085 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1148 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_4:
-# 1087 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1150 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_5:
-# 1089 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1152 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_6:
-# 1091 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1154 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyWhite
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_7:
-# 1093 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1156 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen::
-# 1101 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1165 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_GREEN
-# 1102 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1166 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1103 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1167 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1168 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1104 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1169 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue::
-# 1109 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1174 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_BLUE
-# 1110 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1175 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1111 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1176 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1177 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1112 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1178 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow::
-# 1117 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1183 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_YELLOW
-# 1118 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1184 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1119 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1185 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1186 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1120 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1187 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyWhite::
-# 1125 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1192 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SQUAWKABILLY_WHITE
-# 1126 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1193 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1127 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1194 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1195 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1128 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1196 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm::
-# 1133 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1201 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 1134 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1202 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitmessage
-# 1135 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1203 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_TATSUGIRI_FORM
-# 1136 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1204 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ShowScrollableMultichoice
-# 1137 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1205 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	waitstate
-# 1138 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1206 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	switch VAR_RESULT
-# 1139 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1207 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_3
-# 1141 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1209 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_4
-# 1143 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1211 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case 2, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_5
-# 1145 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1213 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_6
 Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1:
-# 1148 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1216 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1217 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1149 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1218 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_3:
-# 1140 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1208 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_4:
-# 1142 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1210 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_5:
-# 1144 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1212 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_6:
-# 1146 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1214 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly::
-# 1154 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_TATSUGIRI_CURLY
-# 1155 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 1156 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1157 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy::
-# 1162 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_TATSUGIRI_DROOPY
-# 1163 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 1164 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1165 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy::
-# 1170 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_TATSUGIRI_STRETCHY
-# 1171 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 1172 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1173 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm::
-# 1178 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 1179 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 1180 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_DUDUNSPARCE_FORM
-# 1181 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
-# 1182 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 1183 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 1184 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_3
-# 1186 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_4
-# 1188 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_5
-Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1:
-# 1191 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1192 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_3:
-# 1185 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_4:
-# 1187 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_5:
-# 1189 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
-	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo::
-# 1197 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_DUDUNSPARCE_TWO_SEGMENT
-# 1198 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 1199 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1200 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree::
-# 1205 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8009, SPECIES_DUDUNSPARCE_THREE_SEGMENT
-# 1206 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ChangePartyMonForm
-# 1207 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1208 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	release
-	end
-
-
-Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm::
-# 1213 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	msgbox Route121_SafariZoneEntrance_Text_WhichForm
-# 1214 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitmessage
-# 1215 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SINISTCHA_FORM
-# 1216 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	special ShowScrollableMultichoice
-# 1217 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	waitstate
-# 1218 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	switch VAR_RESULT
-# 1219 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_3
-# 1221 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_4
 # 1223 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
-	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_5
-Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1:
+	setvar VAR_0x8009, SPECIES_TATSUGIRI_CURLY
+# 1224 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1225 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
 # 1226 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
 # 1227 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy::
+# 1232 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_TATSUGIRI_DROOPY
+# 1233 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1234 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1235 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1236 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy::
+# 1241 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_TATSUGIRI_STRETCHY
+# 1242 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1243 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1244 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1245 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm::
+# 1250 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1251 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1252 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_DUDUNSPARCE_FORM
+# 1253 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1254 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1255 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1256 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_3
+# 1258 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_4
+# 1260 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1:
+# 1263 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1264 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1265 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_3:
+# 1257 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_4:
+# 1259 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_5:
+# 1261 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
+	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm_1
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo::
+# 1270 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_DUDUNSPARCE_TWO_SEGMENT
+# 1271 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1272 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1273 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1274 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree::
+# 1279 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8009, SPECIES_DUDUNSPARCE_THREE_SEGMENT
+# 1280 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ChangePartyMonForm
+# 1281 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1282 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1283 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
+
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm::
+# 1288 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	msgbox Route121_SafariZoneEntrance_Text_WhichForm
+# 1289 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitmessage
+# 1290 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	setvar VAR_0x8004, SCROLL_MULTI_MANIAC_SINISTCHA_FORM
+# 1291 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	special ShowScrollableMultichoice
+# 1292 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	waitstate
+# 1293 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	switch VAR_RESULT
+# 1294 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 0, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_3
+# 1296 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case 1, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_4
+# 1298 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	case MULTI_B_PRESSED, Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_5
+Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1:
+# 1301 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1302 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
+# 1303 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	release
+	end
+
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_3:
-# 1220 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1295 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_4:
-# 1222 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1297 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaMasterpiece
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1
 
 Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_5:
-# 1224 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1299 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_ManiacDecline
 	goto Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm_1
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable::
-# 1232 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1308 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SINISTCHA_UNREMARKABLE
-# 1233 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1309 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1234 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1310 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1311 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1235 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1312 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaMasterpiece::
-# 1240 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1317 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	setvar VAR_0x8009, SPECIES_SINISTCHA_MASTERPIECE
-# 1241 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1318 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	special ChangePartyMonForm
-# 1242 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1319 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+	closemessage
+# 1320 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	goto Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange
-# 1243 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1321 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange::
-# 1248 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1326 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	fadescreen FADE_TO_BLACK
-# 1249 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1327 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	delay 16
-# 1250 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1328 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	fadescreen FADE_FROM_BLACK
-# 1251 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1329 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	msgbox Route121_SafariZoneEntrance_Text_WhatASpecimen, MSGBOX_DEFAULT
-# 1252 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1330 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	release
 	end
 
 
 Route121_SafariZoneEntrance_EventScript_ManiacWannaChangeForm::
-# 1256 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1334 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	.string "This place is incredible, they have all\n"
 	.string "kinds of species cohabiting. This is\l"
 	.string "the 53rd day in a row I come to visit\l"
@@ -2444,27 +2600,27 @@ Route121_SafariZoneEntrance_EventScript_ManiacWannaChangeForm::
 	.string "me analyze?$"
 
 Maniac_AskAgain::
-# 1268 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1346 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	.string "So, which one should I analyze?$"
 
 Maniac_ComeBackWithOne::
-# 1272 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1350 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	.string "You could have just said you didn't\n"
 	.string "want to share…$"
 
 Route121_SafariZoneEntrance_Text_WhatASpecimen::
-# 1277 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1355 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	.string "I'm done! Thank you so much for giving me\n"
 	.string "this opportunity. I'm so lucky to have\l"
 	.string "met you. Please come back anytime with\l"
 	.string "other ones. Aren't Pokémon amazing?!$"
 
 Route121_SafariZoneEntrance_Text_WhichForm::
-# 1284 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1362 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	.string "Fascinating! Would you like me to change\n"
 	.string "its form?$"
 
 Route121_SafariZoneEntrance_Text_ThisIsntAMon::
-# 1289 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
+# 1367 "data/maps/Route121_SafariZoneEntrance/scripts.pory"
 	.string "What are you, some kind of amateur?\n"
 	.string "This Pokémon can't change forms.$"

--- a/data/maps/Route121_SafariZoneEntrance/scripts.pory
+++ b/data/maps/Route121_SafariZoneEntrance/scripts.pory
@@ -131,3 +131,1162 @@ Route121_SafariZoneEntrance_EventScript_TrainerTipSign::
 	end
 
 `
+
+script Route121_SafariZoneEntrance_EventScript_Maniac{
+	lock 
+	faceplayer
+	goto_if_set(FLAG_TEMP_1, Route121_SafariZoneEntrance_EventScript_ManiacAskAgain)
+	msgbox(Route121_SafariZoneEntrance_EventScript_ManiacWannaChangeForm,MSGBOX_YESNO)
+	call_if_eq(VAR_RESULT, YES, Route121_SafariZoneEntrance_EventScript_ManiacAccept)
+	goto_if_eq(VAR_RESULT, NO, Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	closemessage
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacAskAgain{
+	msgbox(Maniac_AskAgain, MSGBOX_YESNO)
+	goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeForm)
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeForm{
+	call_if_eq(VAR_RESULT, YES, Route121_SafariZoneEntrance_EventScript_ManiacAccept)
+	goto_if_eq(VAR_RESULT, NO, Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	closemessage
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacAccept{
+	special(ChoosePartyMon)
+	waitstate
+	copyvar(VAR_0x800A, VAR_0x8004)
+	goto_if_eq(VAR_0x8004, PARTY_NOTHING_CHOSEN, Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	specialvar(VAR_RESULT, ScriptGetPartyMonSpecies)
+	switch (var(VAR_RESULT)) {
+		case SPECIES_GASTRODON:
+		case SPECIES_GASTRODON_EAST:
+		case SPECIES_GASTRODON_WEST:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm)
+		case SPECIES_SAWSBUCK:
+		case SPECIES_SAWSBUCK_SPRING:
+		case SPECIES_SAWSBUCK_SUMMER:
+		case SPECIES_SAWSBUCK_AUTUMN:
+		case SPECIES_SAWSBUCK_WINTER:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm)
+		case SPECIES_KELDEO:
+		case SPECIES_KELDEO_ORDINARY:
+		case SPECIES_KELDEO_RESOLUTE:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm)
+		case SPECIES_VIVILLON:
+		case SPECIES_VIVILLON_ICY_SNOW:
+		case SPECIES_VIVILLON_POLAR:
+		case SPECIES_VIVILLON_TUNDRA:
+		case SPECIES_VIVILLON_CONTINENTAL:
+		case SPECIES_VIVILLON_GARDEN:
+		case SPECIES_VIVILLON_ELEGANT:
+		case SPECIES_VIVILLON_MEADOW:
+		case SPECIES_VIVILLON_MODERN:
+		case SPECIES_VIVILLON_MARINE:
+		case SPECIES_VIVILLON_ARCHIPELAGO:
+		case SPECIES_VIVILLON_HIGH_PLAINS:
+		case SPECIES_VIVILLON_SANDSTORM:
+		case SPECIES_VIVILLON_RIVER:
+		case SPECIES_VIVILLON_MONSOON:
+		case SPECIES_VIVILLON_SAVANNA:
+		case SPECIES_VIVILLON_SUN:
+		case SPECIES_VIVILLON_OCEAN:
+		case SPECIES_VIVILLON_JUNGLE:
+		case SPECIES_VIVILLON_FANCY:
+		case SPECIES_VIVILLON_POKEBALL:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm)
+		case SPECIES_FLORGES:
+		case SPECIES_FLORGES_RED:
+		case SPECIES_FLORGES_YELLOW:
+		case SPECIES_FLORGES_ORANGE:
+		case SPECIES_FLORGES_BLUE:
+		case SPECIES_FLORGES_WHITE:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm)
+		case SPECIES_FURFROU:
+		case SPECIES_FURFROU_NATURAL:
+		case SPECIES_FURFROU_HEART_TRIM:
+		case SPECIES_FURFROU_STAR_TRIM:
+		case SPECIES_FURFROU_DIAMOND_TRIM:
+		case SPECIES_FURFROU_DEBUTANTE_TRIM:
+		case SPECIES_FURFROU_MATRON_TRIM:
+		case SPECIES_FURFROU_DANDY_TRIM:
+		case SPECIES_FURFROU_LA_REINE_TRIM:
+		case SPECIES_FURFROU_KABUKI_TRIM:
+		case SPECIES_FURFROU_PHARAOH_TRIM:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm)
+		case SPECIES_GOURGEIST:
+		case SPECIES_GOURGEIST_AVERAGE:
+		case SPECIES_GOURGEIST_SMALL:
+		case SPECIES_GOURGEIST_LARGE:
+		case SPECIES_GOURGEIST_SUPER:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm)
+		case SPECIES_MINIOR:
+		case SPECIES_MINIOR_METEOR:
+		case SPECIES_MINIOR_RED:
+		case SPECIES_MINIOR_ORANGE:
+		case SPECIES_MINIOR_YELLOW:
+		case SPECIES_MINIOR_GREEN:
+		case SPECIES_MINIOR_BLUE:
+		case SPECIES_MINIOR_INDIGO:
+		case SPECIES_MINIOR_VIOLET:
+		case SPECIES_MINIOR_METEOR_RED:
+		case SPECIES_MINIOR_METEOR_ORANGE:
+		case SPECIES_MINIOR_METEOR_YELLOW:
+		case SPECIES_MINIOR_METEOR_GREEN:
+		case SPECIES_MINIOR_METEOR_BLUE:
+		case SPECIES_MINIOR_METEOR_INDIGO:
+		case SPECIES_MINIOR_METEOR_VIOLET:
+		case SPECIES_MINIOR_CORE:
+		case SPECIES_MINIOR_CORE_RED:
+		case SPECIES_MINIOR_CORE_ORANGE:
+		case SPECIES_MINIOR_CORE_YELLOW:
+		case SPECIES_MINIOR_CORE_GREEN:
+		case SPECIES_MINIOR_CORE_BLUE:
+		case SPECIES_MINIOR_CORE_INDIGO:
+		case SPECIES_MINIOR_CORE_VIOLET:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm)
+		case SPECIES_MAGEARNA:
+		case SPECIES_MAGEARNA_ORIGINAL:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm)
+		case SPECIES_TOXTRICITY:
+		case SPECIES_TOXTRICITY_AMPED:
+		case SPECIES_TOXTRICITY_LOW_KEY:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm)
+		case SPECIES_POLTEAGEIST:
+		case SPECIES_POLTEAGEIST_PHONY:
+		case SPECIES_POLTEAGEIST_ANTIQUE:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm)
+		case SPECIES_ALCREMIE:
+		case SPECIES_ALCREMIE_STRAWBERRY:
+		case SPECIES_ALCREMIE_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_STRAWBERRY_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_RUBY_CREAM:
+		case SPECIES_ALCREMIE_MATCHA_CREAM:
+		case SPECIES_ALCREMIE_MINT_CREAM:
+		case SPECIES_ALCREMIE_LEMON_CREAM:
+		case SPECIES_ALCREMIE_SALTED_CREAM:
+		case SPECIES_ALCREMIE_RUBY_SWIRL:
+		case SPECIES_ALCREMIE_CARAMEL_SWIRL:
+		case SPECIES_ALCREMIE_RAINBOW_SWIRL:
+		case SPECIES_ALCREMIE_BERRY:
+		case SPECIES_ALCREMIE_BERRY_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_BERRY_RUBY_CREAM:
+		case SPECIES_ALCREMIE_BERRY_MATCHA_CREAM:
+		case SPECIES_ALCREMIE_BERRY_MINT_CREAM:
+		case SPECIES_ALCREMIE_BERRY_LEMON_CREAM:
+		case SPECIES_ALCREMIE_BERRY_SALTED_CREAM:
+		case SPECIES_ALCREMIE_BERRY_RUBY_SWIRL:
+		case SPECIES_ALCREMIE_BERRY_CARAMEL_SWIRL:
+		case SPECIES_ALCREMIE_BERRY_RAINBOW_SWIRL:
+		case SPECIES_ALCREMIE_LOVE:
+		case SPECIES_ALCREMIE_LOVE_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_LOVE_RUBY_CREAM:
+		case SPECIES_ALCREMIE_LOVE_MATCHA_CREAM:
+		case SPECIES_ALCREMIE_LOVE_MINT_CREAM:
+		case SPECIES_ALCREMIE_LOVE_LEMON_CREAM:
+		case SPECIES_ALCREMIE_LOVE_SALTED_CREAM:
+		case SPECIES_ALCREMIE_LOVE_RUBY_SWIRL:
+		case SPECIES_ALCREMIE_LOVE_CARAMEL_SWIRL:
+		case SPECIES_ALCREMIE_LOVE_RAINBOW_SWIRL:
+		case SPECIES_ALCREMIE_STAR:
+		case SPECIES_ALCREMIE_STAR_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_STAR_RUBY_CREAM:
+		case SPECIES_ALCREMIE_STAR_MATCHA_CREAM:
+		case SPECIES_ALCREMIE_STAR_MINT_CREAM:
+		case SPECIES_ALCREMIE_STAR_LEMON_CREAM:
+		case SPECIES_ALCREMIE_STAR_SALTED_CREAM:
+		case SPECIES_ALCREMIE_STAR_RUBY_SWIRL:
+		case SPECIES_ALCREMIE_STAR_CARAMEL_SWIRL:
+		case SPECIES_ALCREMIE_STAR_RAINBOW_SWIRL:
+		case SPECIES_ALCREMIE_CLOVER:
+		case SPECIES_ALCREMIE_CLOVER_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_CLOVER_RUBY_CREAM:
+		case SPECIES_ALCREMIE_CLOVER_MATCHA_CREAM:
+		case SPECIES_ALCREMIE_CLOVER_MINT_CREAM:
+		case SPECIES_ALCREMIE_CLOVER_LEMON_CREAM:
+		case SPECIES_ALCREMIE_CLOVER_SALTED_CREAM:
+		case SPECIES_ALCREMIE_CLOVER_RUBY_SWIRL:
+		case SPECIES_ALCREMIE_CLOVER_CARAMEL_SWIRL:
+		case SPECIES_ALCREMIE_CLOVER_RAINBOW_SWIRL:
+		case SPECIES_ALCREMIE_FLOWER:
+		case SPECIES_ALCREMIE_FLOWER_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_FLOWER_RUBY_CREAM:
+		case SPECIES_ALCREMIE_FLOWER_MATCHA_CREAM:
+		case SPECIES_ALCREMIE_FLOWER_MINT_CREAM:
+		case SPECIES_ALCREMIE_FLOWER_LEMON_CREAM:
+		case SPECIES_ALCREMIE_FLOWER_SALTED_CREAM:
+		case SPECIES_ALCREMIE_FLOWER_RUBY_SWIRL:
+		case SPECIES_ALCREMIE_FLOWER_CARAMEL_SWIRL:
+		case SPECIES_ALCREMIE_FLOWER_RAINBOW_SWIRL:
+		case SPECIES_ALCREMIE_RIBBON:
+		case SPECIES_ALCREMIE_RIBBON_VANILLA_CREAM:
+		case SPECIES_ALCREMIE_RIBBON_RUBY_CREAM:
+		case SPECIES_ALCREMIE_RIBBON_MATCHA_CREAM:
+		case SPECIES_ALCREMIE_RIBBON_MINT_CREAM:
+		case SPECIES_ALCREMIE_RIBBON_LEMON_CREAM:
+		case SPECIES_ALCREMIE_RIBBON_SALTED_CREAM:
+		case SPECIES_ALCREMIE_RIBBON_RUBY_SWIRL:
+		case SPECIES_ALCREMIE_RIBBON_CARAMEL_SWIRL:
+		case SPECIES_ALCREMIE_RIBBON_RAINBOW_SWIRL:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm)
+		case SPECIES_ZARUDE:
+		case SPECIES_ZARUDE_DADA:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm)
+		case SPECIES_MAUSHOLD:
+		case SPECIES_MAUSHOLD_THREE:
+		case SPECIES_MAUSHOLD_FOUR:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm)
+		case SPECIES_SQUAWKABILLY:
+		case SPECIES_SQUAWKABILLY_GREEN:
+		case SPECIES_SQUAWKABILLY_BLUE:
+		case SPECIES_SQUAWKABILLY_YELLOW:
+		case SPECIES_SQUAWKABILLY_WHITE:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm)
+		case SPECIES_TATSUGIRI:
+		case SPECIES_TATSUGIRI_CURLY:
+		case SPECIES_TATSUGIRI_DROOPY:
+		case SPECIES_TATSUGIRI_STRETCHY:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm)
+		case SPECIES_DUDUNSPARCE:
+		case SPECIES_DUDUNSPARCE_TWO_SEGMENT:
+		case SPECIES_DUDUNSPARCE_THREE_SEGMENT:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm)
+		case SPECIES_SINISTCHA:
+		case SPECIES_SINISTCHA_UNREMARKABLE:
+		case SPECIES_SINISTCHA_MASTERPIECE:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm)
+		default:
+			msgbox(Route121_SafariZoneEntrance_Text_ThisIsntAMon, MSGBOX_DEFAULT)
+			release
+			end
+	}
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacDecline {
+	setflag(FLAG_TEMP_1)
+	msgbox(Maniac_ComeBackWithOne, MSGBOX_DEFAULT)
+	release
+	end
+}
+
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_GASTRODON_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonEast)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonWest)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonEast{
+	setvar(VAR_0x8009, SPECIES_GASTRODON_EAST)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonWest{
+	setvar(VAR_0x8009, SPECIES_GASTRODON_WEST)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_SAWSBUCK_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn)
+		case 3:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckWinter)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring{
+	setvar(VAR_0x8009, SPECIES_SAWSBUCK_SPRING)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer{
+	setvar(VAR_0x8009, SPECIES_SAWSBUCK_SUMMER)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn{
+	setvar(VAR_0x8009, SPECIES_SAWSBUCK_AUTUMN)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckWinter{
+	setvar(VAR_0x8009, SPECIES_SAWSBUCK_WINTER)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_KELDEO_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoResolute)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary{
+	setvar(VAR_0x8009, SPECIES_KELDEO_ORDINARY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoResolute{
+	setvar(VAR_0x8009, SPECIES_KELDEO_RESOLUTE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_VIVILLON_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonPokeball)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy{
+	setvar(VAR_0x8009, SPECIES_VIVILLON_FANCY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonPokeball{
+	setvar(VAR_0x8009, SPECIES_VIVILLON_POKEBALL)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_FLORGES_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange)
+		case 3:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue)
+		case 4:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesWhite)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed{
+	setvar(VAR_0x8009, SPECIES_FLORGES_RED)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow{
+	setvar(VAR_0x8009, SPECIES_FLORGES_YELLOW)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange{
+	setvar(VAR_0x8009, SPECIES_FLORGES_ORANGE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue{
+	setvar(VAR_0x8009, SPECIES_FLORGES_BLUE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesWhite{
+	setvar(VAR_0x8009, SPECIES_FLORGES_WHITE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_FURFROU_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar)
+		case 3:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond)
+		case 4:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante)
+		case 5:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron)
+		case 6:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy)
+		case 7:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine)
+		case 8:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki)
+		case 9:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouPharaoh)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural{
+	setvar(VAR_0x8009, SPECIES_FURFROU_NATURAL)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart{
+	setvar(VAR_0x8009, SPECIES_FURFROU_HEART_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar{
+	setvar(VAR_0x8009, SPECIES_FURFROU_STAR_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond{
+	setvar(VAR_0x8009, SPECIES_FURFROU_DIAMOND_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante{
+	setvar(VAR_0x8009, SPECIES_FURFROU_DEBUTANTE_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron{
+	setvar(VAR_0x8009, SPECIES_FURFROU_MATRON_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy{
+	setvar(VAR_0x8009, SPECIES_FURFROU_DANDY_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine{
+	setvar(VAR_0x8009, SPECIES_FURFROU_LA_REINE_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki{
+	setvar(VAR_0x8009, SPECIES_FURFROU_KABUKI_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouPharaoh{
+	setvar(VAR_0x8009, SPECIES_FURFROU_PHARAOH_TRIM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_GOURGEIST_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge)
+		case 3:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage{
+	setvar(VAR_0x8009, SPECIES_GOURGEIST_AVERAGE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall{
+	setvar(VAR_0x8009, SPECIES_GOURGEIST_SMALL)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge{
+	setvar(VAR_0x8009, SPECIES_GOURGEIST_LARGE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper{
+	setvar(VAR_0x8009, SPECIES_GOURGEIST_SUPER)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_MINIOR_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow)
+		case 3:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen)
+		case 4:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue)
+		case 5:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo)
+		case 6:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange{
+	setvar(VAR_0x8009, SPECIES_MINIOR_ORANGE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed{
+	setvar(VAR_0x8009, SPECIES_MINIOR_RED)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow{
+	setvar(VAR_0x8009, SPECIES_MINIOR_YELLOW)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen{
+	setvar(VAR_0x8009, SPECIES_MINIOR_GREEN)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue{
+	setvar(VAR_0x8009, SPECIES_MINIOR_BLUE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo{
+	setvar(VAR_0x8009, SPECIES_MINIOR_INDIGO)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet{
+	setvar(VAR_0x8009, SPECIES_MINIOR_VIOLET)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_MAGEARNA_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna{
+	setvar(VAR_0x8009, SPECIES_MAGEARNA)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal{
+	setvar(VAR_0x8009, SPECIES_MAGEARNA_ORIGINAL)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_TOXTRICITY_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityLowKey)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped{
+	setvar(VAR_0x8009, SPECIES_TOXTRICITY_AMPED)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityLowKey{
+	setvar(VAR_0x8009, SPECIES_TOXTRICITY_LOW_KEY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_POLTEAGEIST_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistAntique)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony{
+	setvar(VAR_0x8009, SPECIES_POLTEAGEIST_PHONY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistAntique{
+	setvar(VAR_0x8009, SPECIES_POLTEAGEIST_ANTIQUE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_ALCREMIE_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieStrawberry)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry{
+	setvar(VAR_0x8009, SPECIES_ALCREMIE_BERRY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla{
+	setvar(VAR_0x8009, SPECIES_ALCREMIE_VANILLA_CREAM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieStrawberry{
+	setvar(VAR_0x8009, SPECIES_ALCREMIE_STRAWBERRY_VANILLA_CREAM)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_ZARUDE_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeZarudeDada)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude{
+	setvar(VAR_0x8009, SPECIES_ZARUDE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeZarudeDada{
+	setvar(VAR_0x8009, SPECIES_ZARUDE_DADA)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_MAUSHOLD_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdFour)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree{
+	setvar(VAR_0x8009, SPECIES_MAUSHOLD_THREE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdFour{
+	setvar(VAR_0x8009, SPECIES_MAUSHOLD_FOUR)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_SQUAWKABILLY_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow)
+		case 3:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyWhite)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen{
+	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_GREEN)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue{
+	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_BLUE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow{
+	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_YELLOW)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyWhite{
+	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_WHITE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_TATSUGIRI_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy)
+		case 2:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly{
+	setvar(VAR_0x8009, SPECIES_TATSUGIRI_CURLY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy{
+	setvar(VAR_0x8009, SPECIES_TATSUGIRI_DROOPY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy{
+	setvar(VAR_0x8009, SPECIES_TATSUGIRI_STRETCHY)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_DUDUNSPARCE_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo{
+	setvar(VAR_0x8009, SPECIES_DUDUNSPARCE_TWO_SEGMENT)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree{
+	setvar(VAR_0x8009, SPECIES_DUDUNSPARCE_THREE_SEGMENT)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm{
+	msgbox(Route121_SafariZoneEntrance_Text_WhichForm)
+	waitmessage
+	setvar(VAR_0x8004, SCROLL_MULTI_MANIAC_SINISTCHA_FORM)
+	special(ShowScrollableMultichoice)
+	waitstate
+	switch (var(VAR_RESULT)) {
+		case 0:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable)
+		case 1:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaMasterpiece)
+		case MULTI_B_PRESSED:
+			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
+	}
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable{
+	setvar(VAR_0x8009, SPECIES_SINISTCHA_UNREMARKABLE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaMasterpiece{
+	setvar(VAR_0x8009, SPECIES_SINISTCHA_MASTERPIECE)
+	special(ChangePartyMonForm)
+	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
+	release
+	end
+}
+
+script Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange{
+	fadescreen(FADE_TO_BLACK)
+	delay(16)
+	fadescreen(FADE_FROM_BLACK)
+	msgbox(Route121_SafariZoneEntrance_Text_WhatASpecimen, MSGBOX_DEFAULT)
+	release
+	end
+}
+
+text Route121_SafariZoneEntrance_EventScript_ManiacWannaChangeForm{
+	"This place is incredible, they have all\n"
+	"kinds of species cohabiting. This is\l"
+	"the 53rd day in a row I come to visit\l"
+	"and I still discover new things!\p"
+	"Recently, I've been really interested\n"
+	"in Pokémon that can have different\l"
+	"forms in the wild.\p"
+	"Do you have such a specimen you'd let\n"
+	"me analyze?"
+}
+
+text Maniac_AskAgain{
+	"So, which one should I analyze?"
+}
+
+text Maniac_ComeBackWithOne{
+	"You could have just said you didn't\n"
+	"want to share…"
+}
+
+text Route121_SafariZoneEntrance_Text_WhatASpecimen{
+	"I'm done! Thank you so much for giving me\n"
+	"this opportunity. I'm so lucky to have\l"
+	"met you. Please come back anytime with\l"
+	"other ones. Aren't Pokémon amazing?!"
+}
+
+text Route121_SafariZoneEntrance_Text_WhichForm{
+	"Fascinating! Would you like me to change\n"
+	"its form?"
+}
+
+text Route121_SafariZoneEntrance_Text_ThisIsntAMon{
+	"What are you, some kind of amateur?\n"
+	"This Pokémon can't change forms."
+}

--- a/data/maps/Route121_SafariZoneEntrance/scripts.pory
+++ b/data/maps/Route121_SafariZoneEntrance/scripts.pory
@@ -388,6 +388,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -396,6 +397,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseGastrodonForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonEast{
 	setvar(VAR_0x8009, SPECIES_GASTRODON_EAST)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -404,6 +406,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonEast{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeGastrodonWest{
 	setvar(VAR_0x8009, SPECIES_GASTRODON_WEST)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -427,6 +430,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -435,6 +439,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseSawsbuckForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring{
 	setvar(VAR_0x8009, SPECIES_SAWSBUCK_SPRING)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -443,6 +448,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSpring{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer{
 	setvar(VAR_0x8009, SPECIES_SAWSBUCK_SUMMER)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -451,6 +457,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckSummer{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn{
 	setvar(VAR_0x8009, SPECIES_SAWSBUCK_AUTUMN)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -459,6 +466,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckAutumn{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSawsbuckWinter{
 	setvar(VAR_0x8009, SPECIES_SAWSBUCK_WINTER)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -478,6 +486,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -486,6 +495,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseKeldeoForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary{
 	setvar(VAR_0x8009, SPECIES_KELDEO_ORDINARY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -494,6 +504,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoOrdinary{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeKeldeoResolute{
 	setvar(VAR_0x8009, SPECIES_KELDEO_RESOLUTE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -513,6 +524,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -521,6 +533,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseVivillonForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy{
 	setvar(VAR_0x8009, SPECIES_VIVILLON_FANCY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -529,6 +542,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonFancy{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeVivillonPokeball{
 	setvar(VAR_0x8009, SPECIES_VIVILLON_POKEBALL)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -554,6 +568,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -562,6 +577,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseFlorgesForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed{
 	setvar(VAR_0x8009, SPECIES_FLORGES_RED)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -570,6 +586,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesRed{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow{
 	setvar(VAR_0x8009, SPECIES_FLORGES_YELLOW)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -578,6 +595,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesYellow{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange{
 	setvar(VAR_0x8009, SPECIES_FLORGES_ORANGE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -586,6 +604,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesOrange{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue{
 	setvar(VAR_0x8009, SPECIES_FLORGES_BLUE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -594,6 +613,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesBlue{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFlorgesWhite{
 	setvar(VAR_0x8009, SPECIES_FLORGES_WHITE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -629,6 +649,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -637,6 +658,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseFurfrouForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural{
 	setvar(VAR_0x8009, SPECIES_FURFROU_NATURAL)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -645,6 +667,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouNatural{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart{
 	setvar(VAR_0x8009, SPECIES_FURFROU_HEART_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -653,6 +676,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouHeart{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar{
 	setvar(VAR_0x8009, SPECIES_FURFROU_STAR_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -661,6 +685,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouStar{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond{
 	setvar(VAR_0x8009, SPECIES_FURFROU_DIAMOND_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -669,6 +694,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDiamond{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante{
 	setvar(VAR_0x8009, SPECIES_FURFROU_DEBUTANTE_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -677,6 +703,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDebutante{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron{
 	setvar(VAR_0x8009, SPECIES_FURFROU_MATRON_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -685,6 +712,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouMatron{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy{
 	setvar(VAR_0x8009, SPECIES_FURFROU_DANDY_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -693,6 +721,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouDandy{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine{
 	setvar(VAR_0x8009, SPECIES_FURFROU_LA_REINE_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -701,6 +730,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouLaReine{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki{
 	setvar(VAR_0x8009, SPECIES_FURFROU_KABUKI_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -709,6 +739,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouKabuki{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeFurfrouPharaoh{
 	setvar(VAR_0x8009, SPECIES_FURFROU_PHARAOH_TRIM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -732,6 +763,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -740,6 +772,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseGourgeistForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage{
 	setvar(VAR_0x8009, SPECIES_GOURGEIST_AVERAGE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -748,6 +781,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistAverage{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall{
 	setvar(VAR_0x8009, SPECIES_GOURGEIST_SMALL)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -756,6 +790,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSmall{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge{
 	setvar(VAR_0x8009, SPECIES_GOURGEIST_LARGE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -764,6 +799,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistLarge{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeGourgeistSuper{
 	setvar(VAR_0x8009, SPECIES_GOURGEIST_SUPER)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -793,6 +829,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -801,6 +838,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseMiniorForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange{
 	setvar(VAR_0x8009, SPECIES_MINIOR_ORANGE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -809,6 +847,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorOrange{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed{
 	setvar(VAR_0x8009, SPECIES_MINIOR_RED)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -817,6 +856,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorRed{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow{
 	setvar(VAR_0x8009, SPECIES_MINIOR_YELLOW)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -825,6 +865,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorYellow{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen{
 	setvar(VAR_0x8009, SPECIES_MINIOR_GREEN)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -833,6 +874,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorGreen{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue{
 	setvar(VAR_0x8009, SPECIES_MINIOR_BLUE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -841,6 +883,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorBlue{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo{
 	setvar(VAR_0x8009, SPECIES_MINIOR_INDIGO)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -849,6 +892,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorIndigo{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMiniorViolet{
 	setvar(VAR_0x8009, SPECIES_MINIOR_VIOLET)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -868,6 +912,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -876,6 +921,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseMagearnaForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna{
 	setvar(VAR_0x8009, SPECIES_MAGEARNA)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -884,6 +930,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearna{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMagearnaOriginal{
 	setvar(VAR_0x8009, SPECIES_MAGEARNA_ORIGINAL)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -903,6 +950,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -911,6 +959,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseToxtricityForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped{
 	setvar(VAR_0x8009, SPECIES_TOXTRICITY_AMPED)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -919,6 +968,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityAmped{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeToxtricityLowKey{
 	setvar(VAR_0x8009, SPECIES_TOXTRICITY_LOW_KEY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -938,6 +988,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -946,6 +997,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChoosePolteageistForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony{
 	setvar(VAR_0x8009, SPECIES_POLTEAGEIST_PHONY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -954,6 +1006,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistPhony{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangePolteageistAntique{
 	setvar(VAR_0x8009, SPECIES_POLTEAGEIST_ANTIQUE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -975,6 +1028,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -983,6 +1037,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseAlcremieForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry{
 	setvar(VAR_0x8009, SPECIES_ALCREMIE_BERRY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -991,6 +1046,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieBerry{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla{
 	setvar(VAR_0x8009, SPECIES_ALCREMIE_VANILLA_CREAM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -999,6 +1055,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieVanilla{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeAlcremieStrawberry{
 	setvar(VAR_0x8009, SPECIES_ALCREMIE_STRAWBERRY_VANILLA_CREAM)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1018,6 +1075,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1026,6 +1084,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseZarudeForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude{
 	setvar(VAR_0x8009, SPECIES_ZARUDE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1034,6 +1093,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeZarude{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeZarudeDada{
 	setvar(VAR_0x8009, SPECIES_ZARUDE_DADA)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1053,6 +1113,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1061,6 +1122,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseMausholdForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree{
 	setvar(VAR_0x8009, SPECIES_MAUSHOLD_THREE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1069,6 +1131,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdThree{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeMausholdFour{
 	setvar(VAR_0x8009, SPECIES_MAUSHOLD_FOUR)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1092,6 +1155,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1100,6 +1164,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseSquawkabillyForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen{
 	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_GREEN)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1108,6 +1173,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyGreen{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue{
 	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_BLUE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1116,6 +1182,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyBlue{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow{
 	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_YELLOW)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1124,6 +1191,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyYellow{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSquawkabillyWhite{
 	setvar(VAR_0x8009, SPECIES_SQUAWKABILLY_WHITE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1145,6 +1213,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1153,6 +1222,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseTatsugiriForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly{
 	setvar(VAR_0x8009, SPECIES_TATSUGIRI_CURLY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1161,6 +1231,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriCurly{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy{
 	setvar(VAR_0x8009, SPECIES_TATSUGIRI_DROOPY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1169,6 +1240,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriDroopy{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeTatsugiriStretchy{
 	setvar(VAR_0x8009, SPECIES_TATSUGIRI_STRETCHY)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1188,6 +1260,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1196,6 +1269,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseDudunsparceForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo{
 	setvar(VAR_0x8009, SPECIES_DUDUNSPARCE_TWO_SEGMENT)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1204,6 +1278,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceTwo{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeDudunsparceThree{
 	setvar(VAR_0x8009, SPECIES_DUDUNSPARCE_THREE_SEGMENT)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1223,6 +1298,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm{
 		case MULTI_B_PRESSED:
 			goto(Route121_SafariZoneEntrance_EventScript_ManiacDecline)
 	}
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1231,6 +1307,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChooseSinistchaForm{
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable{
 	setvar(VAR_0x8009, SPECIES_SINISTCHA_UNREMARKABLE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end
@@ -1239,6 +1316,7 @@ script Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaUnremarkable
 script Route121_SafariZoneEntrance_EventScript_ManiacChangeSinistchaMasterpiece{
 	setvar(VAR_0x8009, SPECIES_SINISTCHA_MASTERPIECE)
 	special(ChangePartyMonForm)
+	closemessage
 	goto(Route121_SafariZoneEntrance_EventScript_Maniac_FinishFormChange)
 	release
 	end

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -171,6 +171,7 @@ gSpecials::
 	def_special StartWallyTutorialBattle
 	def_special ChangePokemonNickname
 	def_special ChoosePartyMon
+	def_special ChangePartyMonForm
 	def_special LoadOpponentPartyIntoPlayerParty
 	def_special DisplayPartyForTeamPreview
 	def_special ReloadPlayerParty

--- a/include/constants/field_specials.h
+++ b/include/constants/field_specials.h
@@ -40,6 +40,24 @@
 #define SCROLL_MULTI_BF_MOVE_TUTOR_2                        10
 #define SCROLL_MULTI_SS_TIDAL_DESTINATION                   11
 #define SCROLL_MULTI_BATTLE_TENT_RULES                      12
+#define SCROLL_MULTI_MANIAC_GASTRODON_FORM                  13
+#define SCROLL_MULTI_MANIAC_SAWSBUCK_FORM                   14
+#define SCROLL_MULTI_MANIAC_KELDEO_FORM                     15
+#define SCROLL_MULTI_MANIAC_VIVILLON_FORM                   16
+#define SCROLL_MULTI_MANIAC_FLORGES_FORM                    17
+#define SCROLL_MULTI_MANIAC_FURFROU_FORM                    18
+#define SCROLL_MULTI_MANIAC_GOURGEIST_FORM                  19
+#define SCROLL_MULTI_MANIAC_MINIOR_FORM                     20
+#define SCROLL_MULTI_MANIAC_MAGEARNA_FORM                   21
+#define SCROLL_MULTI_MANIAC_TOXTRICITY_FORM                 22
+#define SCROLL_MULTI_MANIAC_POLTEAGEIST_FORM                23
+#define SCROLL_MULTI_MANIAC_ALCREMIE_FORM                   24
+#define SCROLL_MULTI_MANIAC_ZARUDE_FORM                     25
+#define SCROLL_MULTI_MANIAC_MAUSHOLD_FORM                   26
+#define SCROLL_MULTI_MANIAC_SQUAWKABILLY_FORM               27
+#define SCROLL_MULTI_MANIAC_TATSUGIRI_FORM                  28
+#define SCROLL_MULTI_MANIAC_DUDUNSPARCE_FORM                29
+#define SCROLL_MULTI_MANIAC_SINISTCHA_FORM                  30
 
 #define MAX_SCROLL_MULTI_ON_SCREEN 6
 #define MAX_SCROLL_MULTI_LENGTH 16

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -1580,6 +1580,16 @@ u16 ScriptGetPartyMonSpecies(void)
     return GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPECIES_OR_EGG, NULL);
 }
 
+void ChangePartyMonForm(void)
+{
+    u16 targetSpecies = gSpecialVar_0x8009;
+    struct Pokemon *mon = &gPlayerParty[gSpecialVar_0x800A];
+
+    SetMonData(mon, MON_DATA_SPECIES, &targetSpecies);
+    TrySetDayLimitToFormChange(mon);
+    CalculateMonStats(mon);
+}
+
 u16 ScriptGetPartyMonLevel(void)
 {
     return GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_LEVEL);
@@ -2292,141 +2302,67 @@ void BufferBattleTowerElevatorFloors(void)
 #define tTaskId              data[15]
 // data[9] and [10] unused
 
-void ShowScrollableMultichoice(void)
-{
-    u8 taskId = CreateTask(Task_ShowScrollableMultichoice, 8);
-    struct Task *task = &gTasks[taskId];
-    task->tScrollMultiId = gSpecialVar_0x8004;
+static const u8 sText_ManiacGastrodonEast[] = _("EAST");
+static const u8 sText_ManiacGastrodonWest[] = _("WEST");
+static const u8 sText_ManiacSawsbuckSpring[] = _("SPRING");
+static const u8 sText_ManiacSawsbuckSummer[] = _("SUMMER");
+static const u8 sText_ManiacSawsbuckAutumn[] = _("AUTUMN");
+static const u8 sText_ManiacSawsbuckWinter[] = _("WINTER");
+static const u8 sText_ManiacKeldeoOrdinary[] = _("ORDINARY");
+static const u8 sText_ManiacKeldeoResolute[] = _("RESOLUTE");
+static const u8 sText_ManiacVivillonFancy[] = _("FANCY");
+static const u8 sText_ManiacVivillonPokeball[] = _("POKéBALL");
+static const u8 sText_ManiacFlorgesRed[] = _("RED");
+static const u8 sText_ManiacFlorgesYellow[] = _("YELLOW");
+static const u8 sText_ManiacFlorgesOrange[] = _("ORANGE");
+static const u8 sText_ManiacFlorgesBlue[] = _("BLUE");
+static const u8 sText_ManiacFlorgesWhite[] = _("WHITE");
+static const u8 sText_ManiacFurfrouNatural[] = _("NATURAL");
+static const u8 sText_ManiacFurfrouHeart[] = _("HEART");
+static const u8 sText_ManiacFurfrouStar[] = _("STAR");
+static const u8 sText_ManiacFurfrouDiamond[] = _("DIAMOND");
+static const u8 sText_ManiacFurfrouDebutante[] = _("DEBUTANTE");
+static const u8 sText_ManiacFurfrouMatron[] = _("MATRON");
+static const u8 sText_ManiacFurfrouDandy[] = _("DANDY");
+static const u8 sText_ManiacFurfrouLaReine[] = _("LA REINE");
+static const u8 sText_ManiacFurfrouKabuki[] = _("KABUKI");
+static const u8 sText_ManiacFurfrouPharaoh[] = _("PHARAOH");
+static const u8 sText_ManiacGourgeistAverage[] = _("AVERAGE");
+static const u8 sText_ManiacGourgeistSmall[] = _("SMALL");
+static const u8 sText_ManiacGourgeistLarge[] = _("LARGE");
+static const u8 sText_ManiacGourgeistSuper[] = _("SUPER");
+static const u8 sText_ManiacMiniorOrange[] = _("ORANGE");
+static const u8 sText_ManiacMiniorRed[] = _("RED");
+static const u8 sText_ManiacMiniorYellow[] = _("YELLOW");
+static const u8 sText_ManiacMiniorGreen[] = _("GREEN");
+static const u8 sText_ManiacMiniorBlue[] = _("BLUE");
+static const u8 sText_ManiacMiniorIndigo[] = _("INDIGO");
+static const u8 sText_ManiacMiniorViolet[] = _("VIOLET");
+static const u8 sText_ManiacMagearna[] = _("BASE");
+static const u8 sText_ManiacMagearnaOriginal[] = _("ORIGINAL");
+static const u8 sText_ManiacToxtricityAmped[] = _("AMPED");
+static const u8 sText_ManiacToxtricityLowKey[] = _("LOW-KEY");
+static const u8 sText_ManiacPolteageistPhony[] = _("PHONY");
+static const u8 sText_ManiacPolteageistAntique[] = _("ANTIQUE");
+static const u8 sText_ManiacAlcremieBerry[] = _("BERRY");
+static const u8 sText_ManiacAlcremieVanilla[] = _("VANILLA CREAM");
+static const u8 sText_ManiacAlcremieStrawberry[] = _("STRAWBERRY CREAM");
+static const u8 sText_ManiacZarude[] = _("BASE");
+static const u8 sText_ManiacZarudeDada[] = _("DADA");
+static const u8 sText_ManiacMausholdThree[] = _("THREE");
+static const u8 sText_ManiacMausholdFour[] = _("FOUR");
+static const u8 sText_ManiacSquawkabillyGreen[] = _("GREEN");
+static const u8 sText_ManiacSquawkabillyBlue[] = _("BLUE");
+static const u8 sText_ManiacSquawkabillyYellow[] = _("YELLOW");
+static const u8 sText_ManiacSquawkabillyWhite[] = _("WHITE");
+static const u8 sText_ManiacTatsugiriCurly[] = _("CURLY");
+static const u8 sText_ManiacTatsugiriDroopy[] = _("DROOPY");
+static const u8 sText_ManiacTatsugiriStretchy[] = _("STRETCHY");
+static const u8 sText_ManiacDudunsparceTwo[] = _("TWO SEGMENT");
+static const u8 sText_ManiacDudunsparceThree[] = _("THREE SEGMENT");
+static const u8 sText_ManiacSinistchaUnremarkable[] = _("UNREMARKABLE");
+static const u8 sText_ManiacSinistchaMasterpiece[] = _("MASTERPIECE");
 
-    switch (gSpecialVar_0x8004)
-    {
-    case SCROLL_MULTI_NONE:
-        task->tMaxItemsOnScreen = 1;
-        task->tNumItems = 1;
-        task->tLeft = 1;
-        task->tTop = 1;
-        task->tWidth = 1;
-        task->tHeight = 1;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_GLASS_WORKSHOP_VENDOR:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN - 1;
-        task->tNumItems = 8;
-        task->tLeft = 1;
-        task->tTop = 1;
-        task->tWidth = 9;
-        task->tHeight = 10;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_POKEMON_FAN_CLUB_RATER:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 12;
-        task->tLeft = 1;
-        task->tTop = 1;
-        task->tWidth = 7;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BF_EXCHANGE_CORNER_BUFF_ITEM_VENDOR:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 8;
-        task->tLeft = 14;
-        task->tTop = 1;
-        task->tWidth = 15;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BF_EXCHANGE_CORNER_DEFENSE_ITEM_VENDOR:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 15;
-        task->tLeft = 14;
-        task->tTop = 1;
-        task->tWidth = 15;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BF_EXCHANGE_CORNER_OFFENSE_ITEM_VENDOR:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 12;
-        task->tLeft = 14;
-        task->tTop = 1;
-        task->tWidth = 15;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BF_EXCHANGE_CORNER_UTILITY_ITEM_VENDOR:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 8;
-        task->tLeft = 14;
-        task->tTop = 1;
-        task->tWidth = 15;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BERRY_POWDER_VENDOR:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 12;
-        task->tLeft = 15;
-        task->tTop = 1;
-        task->tWidth = 14;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BF_RECEPTIONIST:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 10;
-        task->tLeft = 17;
-        task->tTop = 1;
-        task->tWidth = 11;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BF_MOVE_TUTOR_1:
-    case SCROLL_MULTI_BF_MOVE_TUTOR_2:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 11;
-        task->tLeft = 15;
-        task->tTop = 1;
-        task->tWidth = 14;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_SS_TIDAL_DESTINATION:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 7;
-        task->tLeft = 19;
-        task->tTop = 1;
-        task->tWidth = 10;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    case SCROLL_MULTI_BATTLE_TENT_RULES:
-        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 7;
-        task->tLeft = 17;
-        task->tTop = 1;
-        task->tWidth = 12;
-        task->tHeight = 12;
-        task->tKeepOpenAfterSelect = FALSE;
-        task->tTaskId = taskId;
-        break;
-    default:
-        gSpecialVar_Result = MULTI_B_PRESSED;
-        DestroyTask(taskId);
-        break;
-    }
-}
 
 static const u8 *const sScrollableMultichoiceOptions[][MAX_SCROLL_MULTI_LENGTH] =
 {
@@ -2590,8 +2526,315 @@ static const u8 *const sScrollableMultichoiceOptions[][MAX_SCROLL_MULTI_LENGTH] 
         gText_Underpowered,
         gText_WhenInDanger,
         gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_GASTRODON_FORM] =
+    {
+        sText_ManiacGastrodonEast,
+        sText_ManiacGastrodonWest,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_SAWSBUCK_FORM] =
+    {
+        sText_ManiacSawsbuckSpring,
+        sText_ManiacSawsbuckSummer,
+        sText_ManiacSawsbuckAutumn,
+        sText_ManiacSawsbuckWinter,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_KELDEO_FORM] =
+    {
+        sText_ManiacKeldeoOrdinary,
+        sText_ManiacKeldeoResolute,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_VIVILLON_FORM] =
+    {
+        sText_ManiacVivillonFancy,
+        sText_ManiacVivillonPokeball,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_FLORGES_FORM] =
+    {
+        sText_ManiacFlorgesRed,
+        sText_ManiacFlorgesYellow,
+        sText_ManiacFlorgesOrange,
+        sText_ManiacFlorgesBlue,
+        sText_ManiacFlorgesWhite,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_FURFROU_FORM] =
+    {
+        sText_ManiacFurfrouNatural,
+        sText_ManiacFurfrouHeart,
+        sText_ManiacFurfrouStar,
+        sText_ManiacFurfrouDiamond,
+        sText_ManiacFurfrouDebutante,
+        sText_ManiacFurfrouMatron,
+        sText_ManiacFurfrouDandy,
+        sText_ManiacFurfrouLaReine,
+        sText_ManiacFurfrouKabuki,
+        sText_ManiacFurfrouPharaoh,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_GOURGEIST_FORM] =
+    {
+        sText_ManiacGourgeistAverage,
+        sText_ManiacGourgeistSmall,
+        sText_ManiacGourgeistLarge,
+        sText_ManiacGourgeistSuper,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_MINIOR_FORM] =
+    {
+        sText_ManiacMiniorOrange,
+        sText_ManiacMiniorRed,
+        sText_ManiacMiniorYellow,
+        sText_ManiacMiniorGreen,
+        sText_ManiacMiniorBlue,
+        sText_ManiacMiniorIndigo,
+        sText_ManiacMiniorViolet,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_MAGEARNA_FORM] =
+    {
+        sText_ManiacMagearna,
+        sText_ManiacMagearnaOriginal,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_TOXTRICITY_FORM] =
+    {
+        sText_ManiacToxtricityAmped,
+        sText_ManiacToxtricityLowKey,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_POLTEAGEIST_FORM] =
+    {
+        sText_ManiacPolteageistPhony,
+        sText_ManiacPolteageistAntique,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_ALCREMIE_FORM] =
+    {
+        sText_ManiacAlcremieBerry,
+        sText_ManiacAlcremieVanilla,
+        sText_ManiacAlcremieStrawberry,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_ZARUDE_FORM] =
+    {
+        sText_ManiacZarude,
+        sText_ManiacZarudeDada,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_MAUSHOLD_FORM] =
+    {
+        sText_ManiacMausholdThree,
+        sText_ManiacMausholdFour,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_SQUAWKABILLY_FORM] =
+    {
+        sText_ManiacSquawkabillyGreen,
+        sText_ManiacSquawkabillyBlue,
+        sText_ManiacSquawkabillyYellow,
+        sText_ManiacSquawkabillyWhite,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_TATSUGIRI_FORM] =
+    {
+        sText_ManiacTatsugiriCurly,
+        sText_ManiacTatsugiriDroopy,
+        sText_ManiacTatsugiriStretchy,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_DUDUNSPARCE_FORM] =
+    {
+        sText_ManiacDudunsparceTwo,
+        sText_ManiacDudunsparceThree,
+        gText_Exit
+    },
+    [SCROLL_MULTI_MANIAC_SINISTCHA_FORM] =
+    {
+        sText_ManiacSinistchaUnremarkable,
+        sText_ManiacSinistchaMasterpiece,
+        gText_Exit
     }
 };
+
+void ShowScrollableMultichoice(void)
+{
+    u8 taskId = CreateTask(Task_ShowScrollableMultichoice, 8);
+    struct Task *task = &gTasks[taskId];
+    task->tScrollMultiId = gSpecialVar_0x8004;
+
+    switch (gSpecialVar_0x8004)
+    {
+    case SCROLL_MULTI_NONE:
+        task->tMaxItemsOnScreen = 1;
+        task->tNumItems = 1;
+        task->tLeft = 1;
+        task->tTop = 1;
+        task->tWidth = 1;
+        task->tHeight = 1;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_GLASS_WORKSHOP_VENDOR:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN - 1;
+        task->tNumItems = 8;
+        task->tLeft = 1;
+        task->tTop = 1;
+        task->tWidth = 9;
+        task->tHeight = 10;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_POKEMON_FAN_CLUB_RATER:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 12;
+        task->tLeft = 1;
+        task->tTop = 1;
+        task->tWidth = 7;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BF_EXCHANGE_CORNER_BUFF_ITEM_VENDOR:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 8;
+        task->tLeft = 14;
+        task->tTop = 1;
+        task->tWidth = 15;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BF_EXCHANGE_CORNER_DEFENSE_ITEM_VENDOR:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 15;
+        task->tLeft = 14;
+        task->tTop = 1;
+        task->tWidth = 15;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BF_EXCHANGE_CORNER_OFFENSE_ITEM_VENDOR:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 12;
+        task->tLeft = 14;
+        task->tTop = 1;
+        task->tWidth = 15;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BF_EXCHANGE_CORNER_UTILITY_ITEM_VENDOR:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 8;
+        task->tLeft = 14;
+        task->tTop = 1;
+        task->tWidth = 15;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BERRY_POWDER_VENDOR:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 12;
+        task->tLeft = 15;
+        task->tTop = 1;
+        task->tWidth = 14;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BF_RECEPTIONIST:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 10;
+        task->tLeft = 17;
+        task->tTop = 1;
+        task->tWidth = 11;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BF_MOVE_TUTOR_1:
+    case SCROLL_MULTI_BF_MOVE_TUTOR_2:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 11;
+        task->tLeft = 15;
+        task->tTop = 1;
+        task->tWidth = 14;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_SS_TIDAL_DESTINATION:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 7;
+        task->tLeft = 19;
+        task->tTop = 1;
+        task->tWidth = 10;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_BATTLE_TENT_RULES:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 7;
+        task->tLeft = 17;
+        task->tTop = 1;
+        task->tWidth = 12;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_MANIAC_GASTRODON_FORM:
+    case SCROLL_MULTI_MANIAC_SAWSBUCK_FORM:
+    case SCROLL_MULTI_MANIAC_KELDEO_FORM:
+    case SCROLL_MULTI_MANIAC_VIVILLON_FORM:
+    case SCROLL_MULTI_MANIAC_FLORGES_FORM:
+    case SCROLL_MULTI_MANIAC_FURFROU_FORM:
+    case SCROLL_MULTI_MANIAC_GOURGEIST_FORM:
+    case SCROLL_MULTI_MANIAC_MINIOR_FORM:
+    case SCROLL_MULTI_MANIAC_MAGEARNA_FORM:
+    case SCROLL_MULTI_MANIAC_TOXTRICITY_FORM:
+    case SCROLL_MULTI_MANIAC_POLTEAGEIST_FORM:
+    case SCROLL_MULTI_MANIAC_ALCREMIE_FORM:
+    case SCROLL_MULTI_MANIAC_ZARUDE_FORM:
+    case SCROLL_MULTI_MANIAC_MAUSHOLD_FORM:
+    case SCROLL_MULTI_MANIAC_SQUAWKABILLY_FORM:
+    case SCROLL_MULTI_MANIAC_TATSUGIRI_FORM:
+    case SCROLL_MULTI_MANIAC_DUDUNSPARCE_FORM:
+    case SCROLL_MULTI_MANIAC_SINISTCHA_FORM:
+    {
+        u32 count = 0;
+        u32 visible;
+        while (count < MAX_SCROLL_MULTI_LENGTH
+            && sScrollableMultichoiceOptions[gSpecialVar_0x8004][count] != NULL)
+            count++;
+
+        visible = (count < MAX_SCROLL_MULTI_ON_SCREEN) ? count : MAX_SCROLL_MULTI_ON_SCREEN;
+
+        task->tMaxItemsOnScreen = visible;
+        task->tNumItems = count;
+        task->tLeft = 23;
+        // Each menu row takes 2 tiles; window frame adds 2 tiles.
+        // tTop pushes the window down so short lists don't float near the top.
+        task->tHeight = (visible * 2);
+        task->tTop = 13 - task->tHeight;
+        task->tWidth = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    }
+    default:
+        gSpecialVar_Result = MULTI_B_PRESSED;
+        DestroyTask(taskId);
+        break;
+    }
+}
 
 static void Task_ShowScrollableMultichoice(u8 taskId)
 {


### PR DESCRIPTION
## Description
- Safari Zone Entrance now has an NPC that can change the form of your Pokémon if it is Gastrodon, Sawsbuck, Gourgeist, Keldeo, Vivillon, Florges, Furfrou, Minior, Magearna, Toxtricity, Polteageist, Alcremie, Zarude, Maushold, Squawkabilly, Tatsugiri, Dudunsparce or Sinistcha. 
The Ivs, shininess and other attributes remain the same. 

## Images
<img width="1678" height="944" alt="image" src="https://github.com/user-attachments/assets/24725884-bcc8-4613-a40f-4527134a1ee6" />
<img width="1678" height="944" alt="image" src="https://github.com/user-attachments/assets/c138853f-1d0a-4279-9c7e-5f100884c8aa" />


## Things to note in the release changelog:
- Safari Zone Entrance now has an NPC that can change the form of your Pokémon if it is Gastrodon, Sawsbuck, Gourgeist, Keldeo, Vivillon, Florges, Furfrou, Minior, Magearna, Toxtricity, Polteageist, Alcremie, Zarude, Maushold, Squawkabilly, Tatsugiri, Dudunsparce or Sinistcha. 

## **Discord contact info**
MaximeGr
